### PR TITLE
Feat/popup improvements

### DIFF
--- a/popup/index.js
+++ b/popup/index.js
@@ -101,13 +101,14 @@ class IRNMNPopup extends HTMLElement {
         );
 
         // Automatically show the modal if init-show is true
-        if (this.initShow) {
-            if (document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', () => this.showModal());
-            } else {
-                await this.showModal();
-            }
+        if (!this.initShow) return;
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.showModal());
+            return;
         }
+
+        await this.showModal();
     }
 
     /**

--- a/popup/index.js
+++ b/popup/index.js
@@ -215,10 +215,6 @@ class IRNMNPopup extends HTMLElement {
         modal.setAttribute('aria-hidden', 'false');
         modal.focus();
 
-        if (this.sessionKey) {
-            sessionStorage.setItem(this.sessionKey, 'shown');
-        }
-
         // Dispatch the `irnmn-modal-opened` event
         this.dispatchEvent(
             new CustomEvent('irnmn-modal-opened', {
@@ -238,6 +234,12 @@ class IRNMNPopup extends HTMLElement {
         modal.classList.remove('irnmn-modal--visible');
         modal.setAttribute('aria-hidden', 'true');
 
+        if (this.sessionKey) {
+            // Store the session key in sessionStorage to prevent showing the modal again
+            sessionStorage.setItem(this.sessionKey, 'shown');
+        }
+
+        // Restore focus to the last focused element before the modal was opened
         if (this.lastFocusedElement) {
             this.lastFocusedElement.focus();
         }

--- a/popup/readme.md
+++ b/popup/readme.md
@@ -39,22 +39,20 @@ Include the component in your project by adding the custom element definition:
 
 ### Showing the Popup
 
-To programmatically show the popup, call the `showModal` method on the `irnmn-modal` element:
+To programmatically show the popup, call the `open()` method on the `irnmn-modal` element:
 
 ```javascript
-const modal = document.querySelector('irnmn-modal');
-modal.showModal();
+document.querySelector('irnmn-modal').open();
 ```
 
 This will display the modal, set the appropriate accessibility attributes, and dispatch the `irnmn-modal-opened` event.
 
 ### Closing the Popup
 
-To programmatically close the popup, call the `closeModal` method on the `irnmn-modal` element:
+To programmatically close the popup, call the `close()` method on the `irnmn-modal` element:
 
 ```javascript
-const modal = document.querySelector('irnmn-modal');
-modal.closeModal();
+document.querySelector('irnmn-modal').close();
 ```
 
 This will hide the modal, restore focus to the previously focused element, and dispatch the `irnmn-modal-closed` event.


### PR DESCRIPTION
Improvements on the Popup component : 

- Moved session key check to renderPopup() for correct one-time logic.
- Removed modal-close from observedAttributes (no need to re-render on label change).
- Added support for [data-close] elements to trigger modal close.
- Exposed .open() and .close() methods for external JS control.
- Improved init-show handling with DOMContentLoaded fallback.
- Added safety checks for modal existence and focus restoration.