### PR TITLE
Feat/viewtransition popup

### DIFF
--- a/room-card/index.js
+++ b/room-card/index.js
@@ -176,10 +176,6 @@ class IrnmnRoomCard extends HTMLElement {
         // DRY: open modal, refresh slider, set up modal book button close
         function openModalAndSetup(modal) {
             modal.open();
-            const modalSlider = modal.querySelector('irnmn-slider');
-            if (modalSlider) {
-                modalSlider.refresh();
-            }
             const modalBookButtons = modal.querySelectorAll('.--book-button');
             modalBookButtons.forEach((button) => {
                 button.removeEventListener('click', button._modalCloseHandler);

--- a/slider/index.js
+++ b/slider/index.js
@@ -42,7 +42,17 @@ class IRNMNSlider extends HTMLElement {
     }
 
     connectedCallback() {
-        this.initSlider();
+        // Wait for visibility before initializing
+        const observer = new IntersectionObserver(
+            ([entry], obs) => {
+                if (entry.isIntersecting) {
+                    this.initSlider();
+                    obs.disconnect();
+                }
+            },
+            { root: null, threshold: 0 },
+        );
+        observer.observe(this);
     }
 
     /**


### PR DESCRIPTION
- Use View Transition API for smoother irnmn-popup hide/show transition
- Adapt slider to use observer to only init when visible ( to fix a glitch when the slider was in a popup during a transition )
- Update room card to remove the slider.refresh() on modal opening since observer fill this purpose