### PR TITLE
Feat/irnmn 3315/room card analytics

### DIFF
--- a/room-card/index.js
+++ b/room-card/index.js
@@ -160,8 +160,8 @@ class IrnmnRoomCard extends HTMLElement {
     }
 
     /**
-    * Pushes standardized tracking event to dataLayer
-    */
+     * Pushes standardized tracking event to dataLayer
+     */
     pushTrackingEvent(interactionType, elementType = 'roomCard') {
         const roomInfo = this.title;
         const columnLayout = this.columnLayout;
@@ -169,7 +169,12 @@ class IrnmnRoomCard extends HTMLElement {
         const now = Date.now();
 
         if (!interactionType || !roomInfo || !columnLayout) {
-            if (this.debug) console.warn('[RoomCard] Missing data for tracking', { interactionType, roomInfo, columnLayout });
+            if (this.debug)
+                console.warn('[RoomCard] Missing data for tracking', {
+                    interactionType,
+                    roomInfo,
+                    columnLayout,
+                });
             return;
         }
 
@@ -183,10 +188,11 @@ class IrnmnRoomCard extends HTMLElement {
             interactionType,
             elementType,
             columnLayout,
-            roomInfo
+            roomInfo,
         };
 
-        if (this.debug) console.debug('[RoomCard] Pushing to dataLayer:', payload);
+        if (this.debug)
+            console.debug('[RoomCard] Pushing to dataLayer:', payload);
 
         if (window.dataLayer && Array.isArray(window.dataLayer)) {
             window.dataLayer.push(payload);
@@ -202,30 +208,32 @@ class IrnmnRoomCard extends HTMLElement {
     addListeners() {
         /* ANALYTIC TRACKING */
         const expandButtons = this.querySelectorAll('.expand-room-modal');
-        expandButtons.forEach(btn =>
+        expandButtons.forEach((btn) =>
             btn.addEventListener('click', () =>
-                this.pushTrackingEvent('moreInfo', 'roomCard')
-            )
+                this.pushTrackingEvent('moreInfo', 'roomCard'),
+            ),
         );
 
         const bookButtons = this.querySelectorAll('.--book-button');
-        bookButtons.forEach(btn =>
+        bookButtons.forEach((btn) =>
             btn.addEventListener('click', () =>
-                this.pushTrackingEvent('book', 'roomCard')
-            )
+                this.pushTrackingEvent('book', 'roomCard'),
+            ),
         );
 
-        const navButtons = this.querySelectorAll('.room-card__slider-prev, .room-card__slider-next');
-        navButtons.forEach(btn =>
+        const navButtons = this.querySelectorAll(
+            '.room-card__slider-prev, .room-card__slider-next',
+        );
+        navButtons.forEach((btn) =>
             btn.addEventListener('click', () =>
-                this.pushTrackingEvent('carouselClick', 'roomCard')
-            )
+                this.pushTrackingEvent('carouselClick', 'roomCard'),
+            ),
         );
 
         const tourLink = this.querySelector('.room-card__slider-360');
         if (tourLink) {
             tourLink.addEventListener('click', () =>
-                this.pushTrackingEvent('360Tour', 'roomCard')
+                this.pushTrackingEvent('360Tour', 'roomCard'),
             );
         }
 
@@ -307,21 +315,21 @@ class IrnmnRoomCard extends HTMLElement {
             }'>
                 <div class="room-card__slider-container" aria-polite="true" aria-label="${this.labels.slideraria || 'Room images'}">
                     ${this.images
-                .map((img) => {
-                    if (typeof img === 'string') {
-                        return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
-                    } else if (img && typeof img === 'object') {
-                        const srcsetAttr = img.srcset
-                            ? ` srcset="${img.srcset}"`
-                            : '';
-                        const sizesAttr = img.sizes
-                            ? ` sizes="${img.sizes}"`
-                            : '';
-                        return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
-                    }
-                    return '';
-                })
-                .join('')}
+                        .map((img) => {
+                            if (typeof img === 'string') {
+                                return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
+                            } else if (img && typeof img === 'object') {
+                                const srcsetAttr = img.srcset
+                                    ? ` srcset="${img.srcset}"`
+                                    : '';
+                                const sizesAttr = img.sizes
+                                    ? ` sizes="${img.sizes}"`
+                                    : '';
+                                return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
+                            }
+                            return '';
+                        })
+                        .join('')}
                 </div>
                 <div class="room-card__slider-navigation">
                     <button class="room-card__slider-prev" aria-label="${this.labels.prevSlide || 'See previous image'}">
@@ -342,8 +350,9 @@ class IrnmnRoomCard extends HTMLElement {
                         <li></li>
                     </ul>
                 </div>
-                ${this.link360
-                ? `
+                ${
+                    this.link360
+                        ? `
                     <a href="${this.link360}" target="_blank" class="room-card__slider-360" aria-label="${this.labels.view360 || 'View 360 tour'}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16" fill="none">
                         <path d="M10.9016 6.58242V2.85742C10.9016 2.45742 10.6766 2.10742 10.3266 1.95742L7.42656 0.607422C7.15156 0.482422 6.85156 0.482422 6.57656 0.607422L3.67656 1.95742C3.32656 2.13242 3.10156 2.48242 3.10156 2.85742V6.58242C3.10156 6.93242 3.30156 7.28242 3.60156 7.45742L6.50156 9.13242C6.65156 9.23242 6.82656 9.25742 7.00156 9.25742C7.17656 9.25742 7.35156 9.20742 7.50156 9.13242L10.4016 7.45742C10.7266 7.28242 10.9016 6.95742 10.9016 6.58242ZM6.80156 1.05742C6.85156 1.03242 6.92656 1.00742 7.00156 1.00742C7.07656 1.00742 7.15156 1.03242 7.20156 1.05742L10.0766 2.38242L7.00156 3.80742L3.92656 2.38242L6.80156 1.05742ZM3.85156 7.03242C3.70156 6.93242 3.60156 6.78242 3.60156 6.60742V2.85742C3.60156 2.83242 3.60156 2.80742 3.60156 2.78242L6.75156 4.23242V8.68242L3.85156 7.03242ZM10.1516 7.03242L7.25156 8.70742V4.23242L10.4016 2.78242C10.4016 2.80742 10.4016 2.83242 10.4016 2.85742V6.58242C10.4016 6.75742 10.3266 6.93242 10.1516 7.03242Z" fill="white" style="fill:white;fill-opacity:1;"/>
@@ -354,8 +363,8 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.labels.view360 || '360 tour'}
                     </a>
                 `
-                : ''
-            }
+                        : ''
+                }
                 ${this.badgeLabel ? `<span class="room-card__badge">${this.badgeLabel}</span>` : ''}
             </irnmn-slider> `;
     }
@@ -385,10 +394,11 @@ class IrnmnRoomCard extends HTMLElement {
                 <p class="room-card__extras__list" role="list">
                     ${this.extras.map((extra) => `<span role="listitem">${extra}</span>`).join('')}
                 </p>
-                ${moreButton
-                ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
-                : ''
-            }
+                ${
+                    moreButton
+                        ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
+                        : ''
+                }
             </div>
         `;
     }

--- a/room-card/index.js
+++ b/room-card/index.js
@@ -31,7 +31,6 @@ class IrnmnRoomCard extends HTMLElement {
         this.eventCache = new Map(); // for deduplication
         const urlParams = new URLSearchParams(window.location.search);
         this.debug = urlParams.get('debugTracking');
-
     }
 
     /**
@@ -314,21 +313,21 @@ class IrnmnRoomCard extends HTMLElement {
             }'>
                 <div class="room-card__slider-container" aria-polite="true" aria-label="${this.labels.slideraria || 'Room images'}">
                     ${this.images
-                .map((img) => {
-                    if (typeof img === 'string') {
-                        return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
-                    } else if (img && typeof img === 'object') {
-                        const srcsetAttr = img.srcset
-                            ? ` srcset="${img.srcset}"`
-                            : '';
-                        const sizesAttr = img.sizes
-                            ? ` sizes="${img.sizes}"`
-                            : '';
-                        return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
-                    }
-                    return '';
-                })
-                .join('')}
+                        .map((img) => {
+                            if (typeof img === 'string') {
+                                return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
+                            } else if (img && typeof img === 'object') {
+                                const srcsetAttr = img.srcset
+                                    ? ` srcset="${img.srcset}"`
+                                    : '';
+                                const sizesAttr = img.sizes
+                                    ? ` sizes="${img.sizes}"`
+                                    : '';
+                                return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
+                            }
+                            return '';
+                        })
+                        .join('')}
                 </div>
                 <div class="room-card__slider-navigation">
                     <button class="room-card__slider-prev" aria-label="${this.labels.prevSlide || 'See previous image'}">
@@ -349,8 +348,9 @@ class IrnmnRoomCard extends HTMLElement {
                         <li></li>
                     </ul>
                 </div>
-                ${this.link360
-                ? `
+                ${
+                    this.link360
+                        ? `
                     <a href="${this.link360}" target="_blank" class="room-card__slider-360" aria-label="${this.labels.view360 || 'View 360 tour'}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16" fill="none">
                         <path d="M10.9016 6.58242V2.85742C10.9016 2.45742 10.6766 2.10742 10.3266 1.95742L7.42656 0.607422C7.15156 0.482422 6.85156 0.482422 6.57656 0.607422L3.67656 1.95742C3.32656 2.13242 3.10156 2.48242 3.10156 2.85742V6.58242C3.10156 6.93242 3.30156 7.28242 3.60156 7.45742L6.50156 9.13242C6.65156 9.23242 6.82656 9.25742 7.00156 9.25742C7.17656 9.25742 7.35156 9.20742 7.50156 9.13242L10.4016 7.45742C10.7266 7.28242 10.9016 6.95742 10.9016 6.58242ZM6.80156 1.05742C6.85156 1.03242 6.92656 1.00742 7.00156 1.00742C7.07656 1.00742 7.15156 1.03242 7.20156 1.05742L10.0766 2.38242L7.00156 3.80742L3.92656 2.38242L6.80156 1.05742ZM3.85156 7.03242C3.70156 6.93242 3.60156 6.78242 3.60156 6.60742V2.85742C3.60156 2.83242 3.60156 2.80742 3.60156 2.78242L6.75156 4.23242V8.68242L3.85156 7.03242ZM10.1516 7.03242L7.25156 8.70742V4.23242L10.4016 2.78242C10.4016 2.80742 10.4016 2.83242 10.4016 2.85742V6.58242C10.4016 6.75742 10.3266 6.93242 10.1516 7.03242Z" fill="white" style="fill:white;fill-opacity:1;"/>
@@ -361,8 +361,8 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.labels.view360 || '360 tour'}
                     </a>
                 `
-                : ''
-            }
+                        : ''
+                }
                 ${this.badgeLabel ? `<span class="room-card__badge">${this.badgeLabel}</span>` : ''}
             </irnmn-slider> `;
     }
@@ -392,10 +392,11 @@ class IrnmnRoomCard extends HTMLElement {
                 <p class="room-card__extras__list" role="list">
                     ${this.extras.map((extra) => `<span role="listitem">${extra}</span>`).join('')}
                 </p>
-                ${moreButton
-                ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
-                : ''
-            }
+                ${
+                    moreButton
+                        ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
+                        : ''
+                }
             </div>
         `;
     }

--- a/room-card/index.js
+++ b/room-card/index.js
@@ -29,6 +29,9 @@ class IrnmnRoomCard extends HTMLElement {
         // Unique id for this room card, useful for accessibility and modal identification
         this.uniqueId = `card-${Math.random().toString(36).substr(2, 9)}`;
         this.eventCache = new Map(); // for deduplication
+        const urlParams = new URLSearchParams(window.location.search);
+        this.debug = urlParams.get('debugTracking');
+
     }
 
     /**
@@ -119,10 +122,6 @@ class IrnmnRoomCard extends HTMLElement {
         } catch {
             return {};
         }
-    }
-
-    get debug() {
-        return this.hasAttribute('debug');
     }
 
     get columnLayout() {
@@ -315,21 +314,21 @@ class IrnmnRoomCard extends HTMLElement {
             }'>
                 <div class="room-card__slider-container" aria-polite="true" aria-label="${this.labels.slideraria || 'Room images'}">
                     ${this.images
-                        .map((img) => {
-                            if (typeof img === 'string') {
-                                return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
-                            } else if (img && typeof img === 'object') {
-                                const srcsetAttr = img.srcset
-                                    ? ` srcset="${img.srcset}"`
-                                    : '';
-                                const sizesAttr = img.sizes
-                                    ? ` sizes="${img.sizes}"`
-                                    : '';
-                                return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
-                            }
-                            return '';
-                        })
-                        .join('')}
+                .map((img) => {
+                    if (typeof img === 'string') {
+                        return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
+                    } else if (img && typeof img === 'object') {
+                        const srcsetAttr = img.srcset
+                            ? ` srcset="${img.srcset}"`
+                            : '';
+                        const sizesAttr = img.sizes
+                            ? ` sizes="${img.sizes}"`
+                            : '';
+                        return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
+                    }
+                    return '';
+                })
+                .join('')}
                 </div>
                 <div class="room-card__slider-navigation">
                     <button class="room-card__slider-prev" aria-label="${this.labels.prevSlide || 'See previous image'}">
@@ -350,9 +349,8 @@ class IrnmnRoomCard extends HTMLElement {
                         <li></li>
                     </ul>
                 </div>
-                ${
-                    this.link360
-                        ? `
+                ${this.link360
+                ? `
                     <a href="${this.link360}" target="_blank" class="room-card__slider-360" aria-label="${this.labels.view360 || 'View 360 tour'}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16" fill="none">
                         <path d="M10.9016 6.58242V2.85742C10.9016 2.45742 10.6766 2.10742 10.3266 1.95742L7.42656 0.607422C7.15156 0.482422 6.85156 0.482422 6.57656 0.607422L3.67656 1.95742C3.32656 2.13242 3.10156 2.48242 3.10156 2.85742V6.58242C3.10156 6.93242 3.30156 7.28242 3.60156 7.45742L6.50156 9.13242C6.65156 9.23242 6.82656 9.25742 7.00156 9.25742C7.17656 9.25742 7.35156 9.20742 7.50156 9.13242L10.4016 7.45742C10.7266 7.28242 10.9016 6.95742 10.9016 6.58242ZM6.80156 1.05742C6.85156 1.03242 6.92656 1.00742 7.00156 1.00742C7.07656 1.00742 7.15156 1.03242 7.20156 1.05742L10.0766 2.38242L7.00156 3.80742L3.92656 2.38242L6.80156 1.05742ZM3.85156 7.03242C3.70156 6.93242 3.60156 6.78242 3.60156 6.60742V2.85742C3.60156 2.83242 3.60156 2.80742 3.60156 2.78242L6.75156 4.23242V8.68242L3.85156 7.03242ZM10.1516 7.03242L7.25156 8.70742V4.23242L10.4016 2.78242C10.4016 2.80742 10.4016 2.83242 10.4016 2.85742V6.58242C10.4016 6.75742 10.3266 6.93242 10.1516 7.03242Z" fill="white" style="fill:white;fill-opacity:1;"/>
@@ -363,8 +361,8 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.labels.view360 || '360 tour'}
                     </a>
                 `
-                        : ''
-                }
+                : ''
+            }
                 ${this.badgeLabel ? `<span class="room-card__badge">${this.badgeLabel}</span>` : ''}
             </irnmn-slider> `;
     }
@@ -394,11 +392,10 @@ class IrnmnRoomCard extends HTMLElement {
                 <p class="room-card__extras__list" role="list">
                     ${this.extras.map((extra) => `<span role="listitem">${extra}</span>`).join('')}
                 </p>
-                ${
-                    moreButton
-                        ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
-                        : ''
-                }
+                ${moreButton
+                ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
+                : ''
+            }
             </div>
         `;
     }

--- a/room-card/index.js
+++ b/room-card/index.js
@@ -28,6 +28,7 @@ class IrnmnRoomCard extends HTMLElement {
         super();
         // Unique id for this room card, useful for accessibility and modal identification
         this.uniqueId = `card-${Math.random().toString(36).substr(2, 9)}`;
+        this.eventCache = new Map(); // for deduplication
     }
 
     /**
@@ -120,6 +121,14 @@ class IrnmnRoomCard extends HTMLElement {
         }
     }
 
+    get debug() {
+        return this.hasAttribute('debug');
+    }
+
+    get columnLayout() {
+        return this.getAttribute('columns') || 'unknown';
+    }
+
     get arrowSvg() {
         return (
             this.getAttribute('arrow-svg') ||
@@ -151,11 +160,76 @@ class IrnmnRoomCard extends HTMLElement {
     }
 
     /**
+    * Pushes standardized tracking event to dataLayer
+    */
+    pushTrackingEvent(interactionType, elementType = 'roomCard') {
+        const roomInfo = this.title;
+        const columnLayout = this.columnLayout;
+        const eventKey = `${interactionType}:${elementType}:${roomInfo}`;
+        const now = Date.now();
+
+        if (!interactionType || !roomInfo || !columnLayout) {
+            if (this.debug) console.warn('[RoomCard] Missing data for tracking', { interactionType, roomInfo, columnLayout });
+            return;
+        }
+
+        // prevent duplicates within 500ms
+        const last = this.eventCache.get(eventKey);
+        if (last && now - last < 500) return;
+        this.eventCache.set(eventKey, now);
+
+        const payload = {
+            event: 'room_suite',
+            interactionType,
+            elementType,
+            columnLayout,
+            roomInfo
+        };
+
+        if (this.debug) console.debug('[RoomCard] Pushing to dataLayer:', payload);
+
+        if (window.dataLayer && Array.isArray(window.dataLayer)) {
+            window.dataLayer.push(payload);
+        } else if (this.debug) {
+            console.warn('[RoomCard] dataLayer not available', payload);
+        }
+    }
+
+    /**
      * Adds event listeners for modal expansion and slider refresh.
      * @private
      */
     addListeners() {
+        /* ANALYTIC TRACKING */
         const expandButtons = this.querySelectorAll('.expand-room-modal');
+        expandButtons.forEach(btn =>
+            btn.addEventListener('click', () =>
+                this.pushTrackingEvent('moreInfo', 'roomCard')
+            )
+        );
+
+        const bookButtons = this.querySelectorAll('.--book-button');
+        bookButtons.forEach(btn =>
+            btn.addEventListener('click', () =>
+                this.pushTrackingEvent('book', 'roomCard')
+            )
+        );
+
+        const navButtons = this.querySelectorAll('.room-card__slider-prev, .room-card__slider-next');
+        navButtons.forEach(btn =>
+            btn.addEventListener('click', () =>
+                this.pushTrackingEvent('carouselClick', 'roomCard')
+            )
+        );
+
+        const tourLink = this.querySelector('.room-card__slider-360');
+        if (tourLink) {
+            tourLink.addEventListener('click', () =>
+                this.pushTrackingEvent('360Tour', 'roomCard')
+            );
+        }
+
+        /* MODAL OPENING */
         const sliderFigures = this.querySelectorAll('irnmn-slider figure');
         const modal = this.querySelector('.room-modal');
         if ((!expandButtons.length && !sliderFigures.length) || !modal) return;
@@ -233,21 +307,21 @@ class IrnmnRoomCard extends HTMLElement {
             }'>
                 <div class="room-card__slider-container" aria-polite="true" aria-label="${this.labels.slideraria || 'Room images'}">
                     ${this.images
-                        .map((img) => {
-                            if (typeof img === 'string') {
-                                return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
-                            } else if (img && typeof img === 'object') {
-                                const srcsetAttr = img.srcset
-                                    ? ` srcset="${img.srcset}"`
-                                    : '';
-                                const sizesAttr = img.sizes
-                                    ? ` sizes="${img.sizes}"`
-                                    : '';
-                                return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
-                            }
-                            return '';
-                        })
-                        .join('')}
+                .map((img) => {
+                    if (typeof img === 'string') {
+                        return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
+                    } else if (img && typeof img === 'object') {
+                        const srcsetAttr = img.srcset
+                            ? ` srcset="${img.srcset}"`
+                            : '';
+                        const sizesAttr = img.sizes
+                            ? ` sizes="${img.sizes}"`
+                            : '';
+                        return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
+                    }
+                    return '';
+                })
+                .join('')}
                 </div>
                 <div class="room-card__slider-navigation">
                     <button class="room-card__slider-prev" aria-label="${this.labels.prevSlide || 'See previous image'}">
@@ -268,9 +342,8 @@ class IrnmnRoomCard extends HTMLElement {
                         <li></li>
                     </ul>
                 </div>
-                ${
-                    this.link360
-                        ? `
+                ${this.link360
+                ? `
                     <a href="${this.link360}" target="_blank" class="room-card__slider-360" aria-label="${this.labels.view360 || 'View 360 tour'}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16" fill="none">
                         <path d="M10.9016 6.58242V2.85742C10.9016 2.45742 10.6766 2.10742 10.3266 1.95742L7.42656 0.607422C7.15156 0.482422 6.85156 0.482422 6.57656 0.607422L3.67656 1.95742C3.32656 2.13242 3.10156 2.48242 3.10156 2.85742V6.58242C3.10156 6.93242 3.30156 7.28242 3.60156 7.45742L6.50156 9.13242C6.65156 9.23242 6.82656 9.25742 7.00156 9.25742C7.17656 9.25742 7.35156 9.20742 7.50156 9.13242L10.4016 7.45742C10.7266 7.28242 10.9016 6.95742 10.9016 6.58242ZM6.80156 1.05742C6.85156 1.03242 6.92656 1.00742 7.00156 1.00742C7.07656 1.00742 7.15156 1.03242 7.20156 1.05742L10.0766 2.38242L7.00156 3.80742L3.92656 2.38242L6.80156 1.05742ZM3.85156 7.03242C3.70156 6.93242 3.60156 6.78242 3.60156 6.60742V2.85742C3.60156 2.83242 3.60156 2.80742 3.60156 2.78242L6.75156 4.23242V8.68242L3.85156 7.03242ZM10.1516 7.03242L7.25156 8.70742V4.23242L10.4016 2.78242C10.4016 2.80742 10.4016 2.83242 10.4016 2.85742V6.58242C10.4016 6.75742 10.3266 6.93242 10.1516 7.03242Z" fill="white" style="fill:white;fill-opacity:1;"/>
@@ -281,8 +354,8 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.labels.view360 || '360 tour'}
                     </a>
                 `
-                        : ''
-                }
+                : ''
+            }
                 ${this.badgeLabel ? `<span class="room-card__badge">${this.badgeLabel}</span>` : ''}
             </irnmn-slider> `;
     }
@@ -312,11 +385,10 @@ class IrnmnRoomCard extends HTMLElement {
                 <p class="room-card__extras__list" role="list">
                     ${this.extras.map((extra) => `<span role="listitem">${extra}</span>`).join('')}
                 </p>
-                ${
-                    moreButton
-                        ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
-                        : ''
-                }
+                ${moreButton
+                ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
+                : ''
+            }
             </div>
         `;
     }

--- a/stories/css-vars-playground.stories.ts
+++ b/stories/css-vars-playground.stories.ts
@@ -263,7 +263,6 @@ const Template = (args: Record<string, any>) => {
             hotel-amenities='["Spa & Wellness", "High-Speed wifi", "Luxury Concierge", "Private Parking", "Bicycle rental"]'
             labels='{"book" : "${args.bookLabel}" ,"placeholder":"Add dates for prices","heading":"Select date for prices","from":"From","night":"Night","legalText":"(inc taxes and fees)","noRates":"No availability on those dates","noRatesMessage":"Please select different dates"}'
             columns="${args.columns}"
-            debug="true"
             ></irnmn-room-card>
         `)}
       </div>

--- a/stories/css-vars-playground.stories.ts
+++ b/stories/css-vars-playground.stories.ts
@@ -262,7 +262,9 @@ const Template = (args: Record<string, any>) => {
             room-amenities='["Malin+Goetz shower amenities","High-def smart TV", "Mini-bar", "Safe", "Lavazza coffee and tea"]'
             hotel-amenities='["Spa & Wellness", "High-Speed wifi", "Luxury Concierge", "Private Parking", "Bicycle rental"]'
             labels='{"book" : "${args.bookLabel}" ,"placeholder":"Add dates for prices","heading":"Select date for prices","from":"From","night":"Night","legalText":"(inc taxes and fees)","noRates":"No availability on those dates","noRatesMessage":"Please select different dates"}'
-          ></irnmn-room-card>
+            columns="${args.columns}"
+            debug="true"
+            ></irnmn-room-card>
         `)}
       </div>
 


### PR DESCRIPTION
https://ennismore.atlassian.net/browse/IRNMN-3315

Add standardized dataLayer tracking to <irnmn-room-card> component

Changes included:
- Added pushTrackingEvent() method to handle standardized dataLayer.push() calls
- Tracked interactions: moreInfo, book, carouselClick, 360Tour
- Captures roomInfo, elementType, and columnLayout dynamically
- Includes debounce logic to prevent duplicate events on rapid clicks
- Fallback if dataLayer is not available
- Debug mode via debug attribute for local testing
- Layout context (columnLayout) retrieved via Gutenberg room-listing block context (see parent theme PR : https://github.com/ennismore/irnmn-parent-wp-theme/pull/167 )