### PR TITLE
Fix/irnmn 3520/irnmn slider accessibility

### DIFF
--- a/room-card/index.js
+++ b/room-card/index.js
@@ -233,21 +233,21 @@ class IrnmnRoomCard extends HTMLElement {
             }'>
                 <div class="room-card__slider-container" aria-polite="true" aria-label="${this.labels.slideraria || 'Room images'}">
                     ${this.images
-                        .map((img) => {
-                            if (typeof img === 'string') {
-                                return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
-                            } else if (img && typeof img === 'object') {
-                                const srcsetAttr = img.srcset
-                                    ? ` srcset="${img.srcset}"`
-                                    : '';
-                                const sizesAttr = img.sizes
-                                    ? ` sizes="${img.sizes}"`
-                                    : '';
-                                return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
-                            }
-                            return '';
-                        })
-                        .join('')}
+                .map((img) => {
+                    if (typeof img === 'string') {
+                        return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
+                    } else if (img && typeof img === 'object') {
+                        const srcsetAttr = img.srcset
+                            ? ` srcset="${img.srcset}"`
+                            : '';
+                        const sizesAttr = img.sizes
+                            ? ` sizes="${img.sizes}"`
+                            : '';
+                        return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
+                    }
+                    return '';
+                })
+                .join('')}
                 </div>
                 <div class="room-card__slider-navigation">
                     <button class="room-card__slider-prev" aria-label="${this.labels.prevSlide || 'See previous image'}">
@@ -257,7 +257,7 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.arrowSvg}
                     </button>
                 </div>
-                <div class="room-card__slider-indicators">
+                <div class="room-card__slider-indicators" aria-hidden="true">
                     <ul aria-hidden="true">
                         <li></li>
                         <li></li>
@@ -268,9 +268,8 @@ class IrnmnRoomCard extends HTMLElement {
                         <li></li>
                     </ul>
                 </div>
-                ${
-                    this.link360
-                        ? `
+                ${this.link360
+                ? `
                     <a href="${this.link360}" target="_blank" class="room-card__slider-360" aria-label="${this.labels.view360 || 'View 360 tour'}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16" fill="none">
                         <path d="M10.9016 6.58242V2.85742C10.9016 2.45742 10.6766 2.10742 10.3266 1.95742L7.42656 0.607422C7.15156 0.482422 6.85156 0.482422 6.57656 0.607422L3.67656 1.95742C3.32656 2.13242 3.10156 2.48242 3.10156 2.85742V6.58242C3.10156 6.93242 3.30156 7.28242 3.60156 7.45742L6.50156 9.13242C6.65156 9.23242 6.82656 9.25742 7.00156 9.25742C7.17656 9.25742 7.35156 9.20742 7.50156 9.13242L10.4016 7.45742C10.7266 7.28242 10.9016 6.95742 10.9016 6.58242ZM6.80156 1.05742C6.85156 1.03242 6.92656 1.00742 7.00156 1.00742C7.07656 1.00742 7.15156 1.03242 7.20156 1.05742L10.0766 2.38242L7.00156 3.80742L3.92656 2.38242L6.80156 1.05742ZM3.85156 7.03242C3.70156 6.93242 3.60156 6.78242 3.60156 6.60742V2.85742C3.60156 2.83242 3.60156 2.80742 3.60156 2.78242L6.75156 4.23242V8.68242L3.85156 7.03242ZM10.1516 7.03242L7.25156 8.70742V4.23242L10.4016 2.78242C10.4016 2.80742 10.4016 2.83242 10.4016 2.85742V6.58242C10.4016 6.75742 10.3266 6.93242 10.1516 7.03242Z" fill="white" style="fill:white;fill-opacity:1;"/>
@@ -281,8 +280,8 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.labels.view360 || '360 tour'}
                     </a>
                 `
-                        : ''
-                }
+                : ''
+            }
                 ${this.badgeLabel ? `<span class="room-card__badge">${this.badgeLabel}</span>` : ''}
             </irnmn-slider> `;
     }
@@ -312,11 +311,10 @@ class IrnmnRoomCard extends HTMLElement {
                 <p class="room-card__extras__list" role="list">
                     ${this.extras.map((extra) => `<span role="listitem">${extra}</span>`).join('')}
                 </p>
-                ${
-                    moreButton
-                        ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
-                        : ''
-                }
+                ${moreButton
+                ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
+                : ''
+            }
             </div>
         `;
     }

--- a/room-card/index.js
+++ b/room-card/index.js
@@ -233,21 +233,21 @@ class IrnmnRoomCard extends HTMLElement {
             }'>
                 <div class="room-card__slider-container" aria-polite="true" aria-label="${this.labels.slideraria || 'Room images'}">
                     ${this.images
-                .map((img) => {
-                    if (typeof img === 'string') {
-                        return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
-                    } else if (img && typeof img === 'object') {
-                        const srcsetAttr = img.srcset
-                            ? ` srcset="${img.srcset}"`
-                            : '';
-                        const sizesAttr = img.sizes
-                            ? ` sizes="${img.sizes}"`
-                            : '';
-                        return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
-                    }
-                    return '';
-                })
-                .join('')}
+                        .map((img) => {
+                            if (typeof img === 'string') {
+                                return `<div class="room-card__slider-slide"><figure><img src="${img}" alt="Room image"></figure></div>`;
+                            } else if (img && typeof img === 'object') {
+                                const srcsetAttr = img.srcset
+                                    ? ` srcset="${img.srcset}"`
+                                    : '';
+                                const sizesAttr = img.sizes
+                                    ? ` sizes="${img.sizes}"`
+                                    : '';
+                                return `<div class="room-card__slider-slide"><figure><img src="${img.url}" ${srcsetAttr} ${sizesAttr} alt="${img.alt || 'Room image'}"></figure></div>`;
+                            }
+                            return '';
+                        })
+                        .join('')}
                 </div>
                 <div class="room-card__slider-navigation">
                     <button class="room-card__slider-prev" aria-label="${this.labels.prevSlide || 'See previous image'}">
@@ -268,8 +268,9 @@ class IrnmnRoomCard extends HTMLElement {
                         <li></li>
                     </ul>
                 </div>
-                ${this.link360
-                ? `
+                ${
+                    this.link360
+                        ? `
                     <a href="${this.link360}" target="_blank" class="room-card__slider-360" aria-label="${this.labels.view360 || 'View 360 tour'}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16" fill="none">
                         <path d="M10.9016 6.58242V2.85742C10.9016 2.45742 10.6766 2.10742 10.3266 1.95742L7.42656 0.607422C7.15156 0.482422 6.85156 0.482422 6.57656 0.607422L3.67656 1.95742C3.32656 2.13242 3.10156 2.48242 3.10156 2.85742V6.58242C3.10156 6.93242 3.30156 7.28242 3.60156 7.45742L6.50156 9.13242C6.65156 9.23242 6.82656 9.25742 7.00156 9.25742C7.17656 9.25742 7.35156 9.20742 7.50156 9.13242L10.4016 7.45742C10.7266 7.28242 10.9016 6.95742 10.9016 6.58242ZM6.80156 1.05742C6.85156 1.03242 6.92656 1.00742 7.00156 1.00742C7.07656 1.00742 7.15156 1.03242 7.20156 1.05742L10.0766 2.38242L7.00156 3.80742L3.92656 2.38242L6.80156 1.05742ZM3.85156 7.03242C3.70156 6.93242 3.60156 6.78242 3.60156 6.60742V2.85742C3.60156 2.83242 3.60156 2.80742 3.60156 2.78242L6.75156 4.23242V8.68242L3.85156 7.03242ZM10.1516 7.03242L7.25156 8.70742V4.23242L10.4016 2.78242C10.4016 2.80742 10.4016 2.83242 10.4016 2.85742V6.58242C10.4016 6.75742 10.3266 6.93242 10.1516 7.03242Z" fill="white" style="fill:white;fill-opacity:1;"/>
@@ -280,8 +281,8 @@ class IrnmnRoomCard extends HTMLElement {
                         ${this.labels.view360 || '360 tour'}
                     </a>
                 `
-                : ''
-            }
+                        : ''
+                }
                 ${this.badgeLabel ? `<span class="room-card__badge">${this.badgeLabel}</span>` : ''}
             </irnmn-slider> `;
     }
@@ -311,10 +312,11 @@ class IrnmnRoomCard extends HTMLElement {
                 <p class="room-card__extras__list" role="list">
                     ${this.extras.map((extra) => `<span role="listitem">${extra}</span>`).join('')}
                 </p>
-                ${moreButton
-                ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
-                : ''
-            }
+                ${
+                    moreButton
+                        ? `<button aria-label="${this.labels.more ? `${this.title} ${this.labels.more}` : `${this.title} More info`}" class="btn btn-secondary expand-room-modal">${this.labels.more || 'More info'}</button>`
+                        : ''
+                }
             </div>
         `;
     }

--- a/slider/index.js
+++ b/slider/index.js
@@ -122,6 +122,10 @@ class IRNMNSlider extends HTMLElement {
             console.error('Swipe container not found');
             return;
         }
+        // Ensure the swipe container has a unique ID
+        if (!swipeContainer.id) {
+            swipeContainer.id = `slider-container-${Math.floor(Math.random() * 1000000)}`;
+        }
         this.setupResizeListener(swipeContainer);
 
         // Initialize slides
@@ -131,10 +135,12 @@ class IRNMNSlider extends HTMLElement {
 
         // Accessbility attributes
         swipeContainer.setAttribute('role', 'region');
-        swipeContainer.setAttribute(
-            'aria-label',
-            'Slideshow with multiple slides',
-        );
+        if (!swipeContainer.hasAttribute('aria-label') && !swipeContainer.hasAttribute('aria-labelledby')) {
+            swipeContainer.setAttribute(
+                'aria-label',
+                'Slideshow with multiple slides',
+            );
+        }
         swipeContainer.setAttribute('tabindex', '0');
         swipeContainer.setAttribute('aria-roledescription', 'carousel');
 
@@ -143,9 +149,11 @@ class IRNMNSlider extends HTMLElement {
 
         if (prevBtn && !prevBtn.hasAttribute('aria-label')) {
             prevBtn.setAttribute('aria-label', 'Previous slide');
+            prevBtn.setAttribute('aria-controls', swipeContainer.id);
         }
         if (nextBtn && !nextBtn.hasAttribute('aria-label')) {
             nextBtn.setAttribute('aria-label', 'Next slide');
+            nextBtn.setAttribute('aria-controls', swipeContainer.id);
         }
 
         const totalSlides = this.slides.length;
@@ -492,10 +500,12 @@ class IRNMNSlider extends HTMLElement {
             } else {
                 slide.setAttribute('role', 'group');
                 slide.setAttribute('aria-roledescription', 'slide');
-                slide.setAttribute(
-                    'aria-label',
-                    `Slide ${i} of ${totalSlides}`,
-                );
+                if (!slide.hasAttribute('aria-label')) {
+                    slide.setAttribute(
+                        'aria-label',
+                        `Slide ${i} of ${totalSlides}`,
+                    );
+                }
             }
         });
     }

--- a/slider/index.js
+++ b/slider/index.js
@@ -8,6 +8,10 @@ class IRNMNSlider extends HTMLElement {
     constructor() {
         super();
         this.CLASSNAMES = this.selectors;
+        // Debug: Log constructor initialization
+        if (this.debug) {
+            console.info('[IRNMNSlider] Constructor called, CLASSNAMES:', this.CLASSNAMES);
+        }
     }
 
     /**
@@ -32,6 +36,10 @@ class IRNMNSlider extends HTMLElement {
         return classnames;
     }
 
+    get debug() {
+        return this.hasAttribute('debug');
+    }
+
     /**
      * Get the transition value from the attribute or fallback
      *
@@ -46,6 +54,9 @@ class IRNMNSlider extends HTMLElement {
         const observer = new IntersectionObserver(
             ([entry], obs) => {
                 if (entry.isIntersecting) {
+                    if (this.debug) {
+                        console.info('[IRNMNSlider] Element is visible, initializing slider...');
+                    }
                     this.initSlider();
                     obs.disconnect();
                 }
@@ -53,6 +64,10 @@ class IRNMNSlider extends HTMLElement {
             { root: null, threshold: 0 },
         );
         observer.observe(this);
+        // Debug: Log when observer is set up
+        if (this.debug) {
+            console.info('[IRNMNSlider] IntersectionObserver set up.');
+        }
     }
 
     /**
@@ -65,6 +80,10 @@ class IRNMNSlider extends HTMLElement {
             element.removeEventListener(event, handler);
         });
         this.eventListeners = [];
+        // Debug: Log cleanup
+        if (this.debug) {
+            console.info('[IRNMNSlider] Event listeners cleaned up.');
+        }
     }
 
     initSlider() {
@@ -95,11 +114,17 @@ class IRNMNSlider extends HTMLElement {
          * Handle single slide case
          */
         if (totalSlides === 1) {
+            if (this.debug) {
+                console.info('[IRNMNSlider] Only one slide detected, rendering single slide.');
+            }
             this.renderSingleSlide(this.slides[0]);
             return;
         }
 
         if (this.dataset.sliderInitialized === 'true') {
+            if (this.debug) {
+                console.info('[IRNMNSlider] Slider already initialized, skipping.');
+            }
             return;
         }
         this.dataset.sliderInitialized = 'true';
@@ -109,6 +134,11 @@ class IRNMNSlider extends HTMLElement {
         this.updateTotalSlides(totalSlides);
         this.initializePosition(swipeContainer);
         this.addEventListeners(swipeContainer, totalSlides);
+
+        // Debug: Log initialization complete
+        if (this.debug) {
+            console.info('[IRNMNSlider] Slider initialization complete.');
+        }
     }
 
     /**
@@ -130,32 +160,12 @@ class IRNMNSlider extends HTMLElement {
                 // Recalculate offsets and center the current slide
                 this.calculateSlideOffsets(swipeContainer);
                 this.centerSlide(swipeContainer);
+
+                // Debug: Log resize event
+                if (this.debug) {
+                    console.info('[IRNMNSlider] Window resized, recalculated offsets and centered slide.');
+                }
             }, 150);
-        };
-
-        window.addEventListener('resize', onResize);
-
-        // Track the resize listener for cleanup
-        this.eventListeners.push({
-            element: window,
-            event: 'resize',
-            handler: onResize,
-        });
-    }
-
-    /**
-     * Sets up the resize event listener to recalculate offsets
-     * and center the current slide when the window is resized.
-     *
-     * @returns {void}
-     */
-    setupResizeListener(swipeContainer) {
-        const onResize = () => {
-            if (!swipeContainer) return;
-
-            // Recalculate offsets and center the current slide
-            this.calculateSlideOffsets(swipeContainer);
-            this.centerSlide(swipeContainer);
         };
 
         window.addEventListener('resize', onResize);
@@ -181,6 +191,11 @@ class IRNMNSlider extends HTMLElement {
         this.querySelector(this.CLASSNAMES.PREV_BUTTON)?.remove();
         this.querySelector(this.CLASSNAMES.NEXT_BUTTON)?.remove();
         this.querySelector(this.CLASSNAMES.CONTROLS)?.remove();
+
+        // Debug: Log single slide rendering
+        if (this.debug) {
+            console.info('[IRNMNSlider] Navigation and controls removed for single slide.');
+        }
     }
 
     /**
@@ -196,6 +211,11 @@ class IRNMNSlider extends HTMLElement {
         this.slides = Array.from(
             swipeContainer.querySelectorAll(this.CLASSNAMES.SLIDES),
         );
+
+        // Debug: Log cloning
+        if (this.debug) {
+            console.info('[IRNMNSlider] Slides cloned for infinite loop. Total slides (with clones):', this.slides.length);
+        }
     }
 
     /**
@@ -213,6 +233,11 @@ class IRNMNSlider extends HTMLElement {
             cumulativeOffset += slide.offsetWidth;
             this.slideOffsets.push(cumulativeOffset);
         });
+
+        // Debug: Log offsets calculation
+        if (this.debug) {
+            console.info('[IRNMNSlider] Slide offsets calculated:', this.slideOffsets);
+        }
     }
 
     /**
@@ -228,6 +253,10 @@ class IRNMNSlider extends HTMLElement {
         if (totalSlidesElem) {
             totalSlidesElem.textContent = totalSlides;
         }
+        // Debug: Log total slides update
+        if (this.debug) {
+            console.info('[IRNMNSlider] Total slides updated:', totalSlides);
+        }
     }
 
     /**
@@ -240,6 +269,11 @@ class IRNMNSlider extends HTMLElement {
         this.currentSlide = 1;
         swipeContainer.style.transition = 'none';
         this.centerSlide(swipeContainer);
+
+        // Debug: Log position initialization
+        if (this.debug) {
+            console.info('[IRNMNSlider] Slider position initialized to slide:', this.currentSlide);
+        }
     }
 
     /**
@@ -282,6 +316,11 @@ class IRNMNSlider extends HTMLElement {
         );
 
         this.addListener(swipeContainer, 'transitionend', resetPosition);
+
+        // Debug: Log event listeners added
+        if (this.debug) {
+            console.info('[IRNMNSlider] Navigation and drag event listeners added.');
+        }
     }
 
     /**
@@ -313,6 +352,11 @@ class IRNMNSlider extends HTMLElement {
         const offset = this.slideOffsets[this.currentSlide];
         const slideWidth = this.slides[this.currentSlide].offsetWidth;
         swipeContainer.style.transform = `translateX(calc(-${offset}px + 50% - ${slideWidth / 2}px))`;
+
+        // Debug: Log centering
+        if (this.debug) {
+            console.info('[IRNMNSlider] Centered slide:', this.currentSlide, 'Offset:', offset, 'Width:', slideWidth);
+        }
     }
 
     /**
@@ -352,6 +396,16 @@ class IRNMNSlider extends HTMLElement {
             },
         });
         swipeContainer.dispatchEvent(slideChangeEvent);
+
+        // Debug: Log slide update
+        if (this.debug) {
+            console.info('[IRNMNSlider] Slide updated:', {
+                currentSlide: this.currentSlide,
+                displayedSlideIndex,
+                totalSlides,
+                clonedSlidesCount,
+            });
+        }
     }
 
     /**
@@ -367,25 +421,41 @@ class IRNMNSlider extends HTMLElement {
         this.centerSlide(swipeContainer);
         this.classList.remove('transitioning-prev');
         this.classList.remove('transitioning-next');
+
+        // Debug: Log position reset
+        if (this.debug) {
+            console.info('[IRNMNSlider] Position reset after transition. Current slide:', this.currentSlide);
+        }
     }
 
     /**
      * Move to the next slide
      */
     moveToNextSlide(updateSlides, clonedSlidesCount) {
+        if (this.classList.contains('transitioning-next') || this.classList.contains('transitioning-prev')) return;
+        this.classList.add('transitioning-next');
         this.currentSlide = (this.currentSlide + 1) % clonedSlidesCount;
         updateSlides();
-        this.classList.add('transitioning-next');
+
+        // Debug: Log next slide
+        if (this.debug) {
+            console.info('[IRNMNSlider] Moved to next slide:', this.currentSlide);
+        }
     }
 
     /**
      * Move to the previous slide
      */
     moveToPrevSlide(updateSlides, clonedSlidesCount) {
-        this.currentSlide =
-            (this.currentSlide - 1 + clonedSlidesCount) % clonedSlidesCount;
-        updateSlides();
+        if (this.classList.contains('transitioning-next') || this.classList.contains('transitioning-prev')) return;
         this.classList.add('transitioning-prev');
+        this.currentSlide = (this.currentSlide - 1 + clonedSlidesCount) % clonedSlidesCount;
+        updateSlides();
+
+        // Debug: Log previous slide
+        if (this.debug) {
+            console.info('[IRNMNSlider] Moved to previous slide:', this.currentSlide);
+        }
     }
 
     /**
@@ -407,6 +477,11 @@ class IRNMNSlider extends HTMLElement {
             startX = e.touches ? e.touches[0].clientX : e.clientX;
             isDragging = true;
             swipeContainer.style.transition = 'none';
+
+            // Debug: Log drag start
+            if (this.debug) {
+                console.info('[IRNMNSlider] Drag/touch start:', startX);
+            }
         };
 
         const touchMove = (e) => {
@@ -415,6 +490,11 @@ class IRNMNSlider extends HTMLElement {
             const offset = this.slideOffsets[this.currentSlide];
             const slideWidth = this.slides[this.currentSlide].offsetWidth;
             swipeContainer.style.transform = `translateX(calc(-${offset}px + 50% - ${slideWidth / 2}px + ${currentX}px))`;
+
+            // Debug: Log drag move
+            if (this.debug) {
+                console.info('[IRNMNSlider] Drag/touch move:', currentX);
+            }
         };
 
         const touchEnd = () => {
@@ -425,6 +505,11 @@ class IRNMNSlider extends HTMLElement {
             else updateSlides();
             currentX = 0;
             isDragging = false;
+
+            // Debug: Log drag end
+            if (this.debug) {
+                console.info('[IRNMNSlider] Drag/touch end.');
+            }
         };
 
         this.addListener(swipeContainer, 'touchstart', touchStart);
@@ -434,6 +519,11 @@ class IRNMNSlider extends HTMLElement {
         this.addListener(swipeContainer, 'mousemove', touchMove);
         this.addListener(swipeContainer, 'mouseup', touchEnd);
         this.addListener(swipeContainer, 'mouseleave', touchEnd);
+
+        // Debug: Log drag and drop setup
+        if (this.debug) {
+            console.info('[IRNMNSlider] Drag and drop/touch listeners set up.');
+        }
     }
 
     refresh() {
@@ -446,6 +536,11 @@ class IRNMNSlider extends HTMLElement {
         }
         this.calculateSlideOffsets(swipeContainer);
         this.centerSlide(swipeContainer);
+
+        // Debug: Log refresh
+        if (this.debug) {
+            console.info('[IRNMNSlider] Slider refreshed.');
+        }
     }
 }
 

--- a/slider/index.js
+++ b/slider/index.js
@@ -135,7 +135,10 @@ class IRNMNSlider extends HTMLElement {
 
         // Accessbility attributes
         swipeContainer.setAttribute('role', 'region');
-        if (!swipeContainer.hasAttribute('aria-label') && !swipeContainer.hasAttribute('aria-labelledby')) {
+        if (
+            !swipeContainer.hasAttribute('aria-label') &&
+            !swipeContainer.hasAttribute('aria-labelledby')
+        ) {
             swipeContainer.setAttribute(
                 'aria-label',
                 'Slideshow with multiple slides',

--- a/slider/index.js
+++ b/slider/index.js
@@ -8,6 +8,8 @@ class IRNMNSlider extends HTMLElement {
     constructor() {
         super();
         this.CLASSNAMES = this.selectors;
+        const urlParams = new URLSearchParams(window.location.search);
+        this.debug = urlParams.get('debugTracking');
         // Debug: Log constructor initialization
         if (this.debug) {
             console.info(
@@ -39,9 +41,6 @@ class IRNMNSlider extends HTMLElement {
         return classnames;
     }
 
-    get debug() {
-        return this.hasAttribute('debug');
-    }
 
     /**
      * Get the transition value from the attribute or fallback.
@@ -606,9 +605,8 @@ class IRNMNSlider extends HTMLElement {
         if (
             focusedElement &&
             this.slides.some(
-                slide =>
-                    slide === focusedElement ||
-                    slide.contains(focusedElement)
+                (slide) =>
+                    slide === focusedElement || slide.contains(focusedElement),
             )
         ) {
             const currentSlideElem = this.slides[this.currentSlide];

--- a/slider/index.js
+++ b/slider/index.js
@@ -10,7 +10,10 @@ class IRNMNSlider extends HTMLElement {
         this.CLASSNAMES = this.selectors;
         // Debug: Log constructor initialization
         if (this.debug) {
-            console.info('[IRNMNSlider] Constructor called, CLASSNAMES:', this.CLASSNAMES);
+            console.info(
+                '[IRNMNSlider] Constructor called, CLASSNAMES:',
+                this.CLASSNAMES,
+            );
         }
     }
 
@@ -55,7 +58,9 @@ class IRNMNSlider extends HTMLElement {
             ([entry], obs) => {
                 if (entry.isIntersecting) {
                     if (this.debug) {
-                        console.info('[IRNMNSlider] Element is visible, initializing slider...');
+                        console.info(
+                            '[IRNMNSlider] Element is visible, initializing slider...',
+                        );
                     }
                     this.initSlider();
                     obs.disconnect();
@@ -115,7 +120,9 @@ class IRNMNSlider extends HTMLElement {
          */
         if (totalSlides === 1) {
             if (this.debug) {
-                console.info('[IRNMNSlider] Only one slide detected, rendering single slide.');
+                console.info(
+                    '[IRNMNSlider] Only one slide detected, rendering single slide.',
+                );
             }
             this.renderSingleSlide(this.slides[0]);
             return;
@@ -123,7 +130,9 @@ class IRNMNSlider extends HTMLElement {
 
         if (this.dataset.sliderInitialized === 'true') {
             if (this.debug) {
-                console.info('[IRNMNSlider] Slider already initialized, skipping.');
+                console.info(
+                    '[IRNMNSlider] Slider already initialized, skipping.',
+                );
             }
             return;
         }
@@ -163,7 +172,9 @@ class IRNMNSlider extends HTMLElement {
 
                 // Debug: Log resize event
                 if (this.debug) {
-                    console.info('[IRNMNSlider] Window resized, recalculated offsets and centered slide.');
+                    console.info(
+                        '[IRNMNSlider] Window resized, recalculated offsets and centered slide.',
+                    );
                 }
             }, 150);
         };
@@ -194,7 +205,9 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log single slide rendering
         if (this.debug) {
-            console.info('[IRNMNSlider] Navigation and controls removed for single slide.');
+            console.info(
+                '[IRNMNSlider] Navigation and controls removed for single slide.',
+            );
         }
     }
 
@@ -214,7 +227,10 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log cloning
         if (this.debug) {
-            console.info('[IRNMNSlider] Slides cloned for infinite loop. Total slides (with clones):', this.slides.length);
+            console.info(
+                '[IRNMNSlider] Slides cloned for infinite loop. Total slides (with clones):',
+                this.slides.length,
+            );
         }
     }
 
@@ -236,7 +252,10 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log offsets calculation
         if (this.debug) {
-            console.info('[IRNMNSlider] Slide offsets calculated:', this.slideOffsets);
+            console.info(
+                '[IRNMNSlider] Slide offsets calculated:',
+                this.slideOffsets,
+            );
         }
     }
 
@@ -272,7 +291,10 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log position initialization
         if (this.debug) {
-            console.info('[IRNMNSlider] Slider position initialized to slide:', this.currentSlide);
+            console.info(
+                '[IRNMNSlider] Slider position initialized to slide:',
+                this.currentSlide,
+            );
         }
     }
 
@@ -319,7 +341,9 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log event listeners added
         if (this.debug) {
-            console.info('[IRNMNSlider] Navigation and drag event listeners added.');
+            console.info(
+                '[IRNMNSlider] Navigation and drag event listeners added.',
+            );
         }
     }
 
@@ -355,7 +379,14 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log centering
         if (this.debug) {
-            console.info('[IRNMNSlider] Centered slide:', this.currentSlide, 'Offset:', offset, 'Width:', slideWidth);
+            console.info(
+                '[IRNMNSlider] Centered slide:',
+                this.currentSlide,
+                'Offset:',
+                offset,
+                'Width:',
+                slideWidth,
+            );
         }
     }
 
@@ -424,7 +455,10 @@ class IRNMNSlider extends HTMLElement {
 
         // Debug: Log position reset
         if (this.debug) {
-            console.info('[IRNMNSlider] Position reset after transition. Current slide:', this.currentSlide);
+            console.info(
+                '[IRNMNSlider] Position reset after transition. Current slide:',
+                this.currentSlide,
+            );
         }
     }
 
@@ -432,14 +466,21 @@ class IRNMNSlider extends HTMLElement {
      * Move to the next slide
      */
     moveToNextSlide(updateSlides, clonedSlidesCount) {
-        if (this.classList.contains('transitioning-next') || this.classList.contains('transitioning-prev')) return;
+        if (
+            this.classList.contains('transitioning-next') ||
+            this.classList.contains('transitioning-prev')
+        )
+            return;
         this.classList.add('transitioning-next');
         this.currentSlide = (this.currentSlide + 1) % clonedSlidesCount;
         updateSlides();
 
         // Debug: Log next slide
         if (this.debug) {
-            console.info('[IRNMNSlider] Moved to next slide:', this.currentSlide);
+            console.info(
+                '[IRNMNSlider] Moved to next slide:',
+                this.currentSlide,
+            );
         }
     }
 
@@ -447,14 +488,22 @@ class IRNMNSlider extends HTMLElement {
      * Move to the previous slide
      */
     moveToPrevSlide(updateSlides, clonedSlidesCount) {
-        if (this.classList.contains('transitioning-next') || this.classList.contains('transitioning-prev')) return;
+        if (
+            this.classList.contains('transitioning-next') ||
+            this.classList.contains('transitioning-prev')
+        )
+            return;
         this.classList.add('transitioning-prev');
-        this.currentSlide = (this.currentSlide - 1 + clonedSlidesCount) % clonedSlidesCount;
+        this.currentSlide =
+            (this.currentSlide - 1 + clonedSlidesCount) % clonedSlidesCount;
         updateSlides();
 
         // Debug: Log previous slide
         if (this.debug) {
-            console.info('[IRNMNSlider] Moved to previous slide:', this.currentSlide);
+            console.info(
+                '[IRNMNSlider] Moved to previous slide:',
+                this.currentSlide,
+            );
         }
     }
 

--- a/slider/index.js
+++ b/slider/index.js
@@ -44,12 +44,18 @@ class IRNMNSlider extends HTMLElement {
     }
 
     /**
-     * Get the transition value from the attribute or fallback
+     * Get the transition value from the attribute or fallback.
+     * Automatically disables transition for users who prefer reduced motion.
      *
      * @returns {string} - The transition string
      */
     get transition() {
-        return this.getAttribute('transition') || '0.3s ease';
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) {
+            return '0.001s ease'; // Disable transition for reduced motion users (very quick transition effect to simulate no transition)
+        }
+        const attr = this.getAttribute('transition');
+        return typeof attr === 'string' && attr.trim() ? attr : '0.3s ease';
     }
 
     connectedCallback() {

--- a/slider/index.js
+++ b/slider/index.js
@@ -468,7 +468,9 @@ class IRNMNSlider extends HTMLElement {
     }
 
     initSlidesAttributes() {
-        const totalSlides = this.querySelectorAll(`${this.CLASSNAMES.SLIDES}:not([data-clone])`).length;
+        const totalSlides = this.querySelectorAll(
+            `${this.CLASSNAMES.SLIDES}:not([data-clone])`,
+        ).length;
 
         this.slides.forEach((slide, i) => {
             const isClone = slide.dataset.clone === 'true';
@@ -482,7 +484,10 @@ class IRNMNSlider extends HTMLElement {
             } else {
                 slide.setAttribute('role', 'group');
                 slide.setAttribute('aria-roledescription', 'slide');
-                slide.setAttribute('aria-label', `Slide ${i} of ${totalSlides}`);
+                slide.setAttribute(
+                    'aria-label',
+                    `Slide ${i} of ${totalSlides}`,
+                );
             }
         });
     }

--- a/slider/index.js
+++ b/slider/index.js
@@ -41,7 +41,6 @@ class IRNMNSlider extends HTMLElement {
         return classnames;
     }
 
-
     /**
      * Get the transition value from the attribute or fallback.
      * Automatically disables transition for users who prefer reduced motion.

--- a/slider/index.js
+++ b/slider/index.js
@@ -50,7 +50,9 @@ class IRNMNSlider extends HTMLElement {
      * @returns {string} - The transition string
      */
     get transition() {
-        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        const prefersReducedMotion = window.matchMedia(
+            '(prefers-reduced-motion: reduce)',
+        ).matches;
         if (prefersReducedMotion) {
             return '0.001s ease'; // Disable transition for reduced motion users (very quick transition effect to simulate no transition)
         }

--- a/slider/index.js
+++ b/slider/index.js
@@ -600,10 +600,21 @@ class IRNMNSlider extends HTMLElement {
         this.classList.remove('transitioning-prev');
         this.classList.remove('transitioning-next');
 
-        //accessibility: set focus on the current slide (after transition end)
-        const currentSlideElem = this.slides[this.currentSlide];
-        if (currentSlideElem) {
-            currentSlideElem.focus();
+        // Ensure focus is returned to the current slide
+        const focusedElement = document.activeElement;
+        // If focus is on the slide itself or anywhere within a slide (including its children), send focus back to the current slide
+        if (
+            focusedElement &&
+            this.slides.some(
+                slide =>
+                    slide === focusedElement ||
+                    slide.contains(focusedElement)
+            )
+        ) {
+            const currentSlideElem = this.slides[this.currentSlide];
+            if (currentSlideElem) {
+                currentSlideElem.focus();
+            }
         }
 
         // Debug: Log position reset

--- a/slider/readme.md
+++ b/slider/readme.md
@@ -2,81 +2,92 @@
 
 **Version:** 1.0
 
-The `IRNMNSlider` web component provides a dynamic and responsive slider that supports touch gestures, mouse dragging, and looping functionality. It is highly customizable using a `selectors` attribute, allowing you to dynamically define class names for internal elements.
+The `IRNMNSlider` web component is a dynamic, accessible, and responsive slider supporting touch gestures, mouse dragging, keyboard navigation, and seamless looping. It is highly customizable via the `selectors` attribute, allowing you to define class names for internal elements.
 
 ---
 
 ## Attributes
 
-The following attributes can be added to the `IRNMNSlider` element to customize its behavior:
-
 | Attribute      | Description                                                                                      | Default Value                |
 |----------------|--------------------------------------------------------------------------------------------------|------------------------------|
 | `selectors`    | A JSON string that defines the class names for key slider elements.                              | N/A (required)               |
-| `transition`    | The CSS transition to be used in the sliders.                              | 0.3 ease               |
+| `transition`   | The CSS transition for slide movement. Automatically disables for users preferring reduced motion.| `0.3s ease`                  |
 
 ### Example `selectors` JSON
 
 ```json
 {
-    "SWIPE_CONTAINER": "slider-container",
-    "SLIDES": "slider-slide",
-    "NAVIGATION": "slider-navigation",
-    "PREV_BUTTON": "slider-prev",
-    "NEXT_BUTTON": "slider-next",
-    "CURRENT_SLIDE": "current-slide",
-    "TOTAL_SLIDES": "total-slides"
+    "SWIPE_CONTAINER": ".slider-container",
+    "SLIDES": ".slider-slide",
+    "NAVIGATION": ".slider-navigation",
+    "PREV_BUTTON": ".slider-prev",
+    "NEXT_BUTTON": ".slider-next",
+    "CURRENT_SLIDE": ".current-slide",
+    "TOTAL_SLIDES": ".total-slides"
 }
 ```
 
 ---
 
+## Accessibility
+
+- Adds an `aria-live` region for announcing slide changes.
+- Sets ARIA roles and labels for slides and navigation.
+- Keyboard navigation: supports Arrow keys, Home/End, and focus management.
+- Cloned slides are hidden from assistive technologies.
+
+---
+
 ## Methods
 
-The following methods are used internally to handle slider functionality and can be extended as needed:
-
-### `selectors`
-Returns an object containing the class names for internal elements, as defined in the `selectors` attribute.
-
-### `initSlider()`
-Initializes the slider. This includes:
-- Cloning the first and last slides to enable seamless looping.
-- Setting up event listeners for navigation, touch gestures, and drag events.
-- Adjusting slide widths dynamically on window resize.
-
-### `updateSlides()`
-Updates the slide position using `transform: translateX()` and updates the current slide indicator.
-
-### `resetPosition()`
-Resets the position when the slider transitions to cloned slides, creating a seamless looping effect.
-
-### `nextSlide()`
-Moves to the next slide.
-
-### `prevSlide()`
-Moves to the previous slide.
+| Method                     | Description                                                                                                             |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `selectors`                | Returns an object containing the class names for internal elements, as defined in the `selectors` attribute.            |
+| `transition`               | Returns the transition string, disables transition for users with reduced motion preference.                            |
+| `initSlider()`             | Initializes the slider, sets up accessibility, clones slides for looping, calculates offsets, and adds event listeners. |
+| `setupResizeListener()`    | Adds a debounced window resize listener to recalculate slide offsets and center the current slide.                      |
+| `renderSingleSlide()`      | Handles the case when only one slide is present: centers the slide and removes navigation controls.                     |
+| `cloneSlides()`            | Clones the first and last slides to enable seamless looping.                                                            |
+| `calculateSlideOffsets()`  | Calculates cumulative offsets for all slides based on their widths.                                                     |
+| `updateTotalSlides()`      | Updates the total slides count in the UI.                                                                               |
+| `initializePosition()`     | Sets the initial slider position and centers the first slide.                                                           |
+| `addEventListeners()`      | Adds navigation, drag, and keyboard event listeners.                                                                    |
+| `addListener()`            | Adds an event listener and tracks it for cleanup.                                                                       |
+| `centerSlide()`            | Centers the currently active slide in the viewport.                                                                     |
+| `initSlidesAttributes()`   | Sets ARIA and accessibility attributes for slides, hiding clones from assistive tech.                                   |
+| `updateSlidesAttributes()` | Updates accessibility attributes and active state for each slide.                                                       |
+| `updateSlides()`           | Updates slide position, pagination, accessibility, and dispatches a `slideChange` event.                                |
+| `resetPosition()`          | Resets the slider position after a transition, handling looping and focus.                                              |
+| `moveToNextSlide()`        | Moves to the next slide, handling looping and transitions.                                                              |
+| `moveToPrevSlide()`        | Moves to the previous slide, handling looping and transitions.                                                          |
+| `setupDragAndDrop()`       | Adds touch and mouse drag event listeners for slide navigation.                                                         |
+| `refresh()`                | Recalculates slide offsets and centers the current slide (use after dynamic content changes).                           |
 
 ---
 
 ## Behavior
 
 ### 1. **Seamless Looping**
-The slider loops seamlessly by cloning the first and last slides. When navigating past the first or last slide, it resets the position to create an infinite loop effect.
+Clones the first and last slides for infinite loop effect. Clones are hidden from screen readers.
 
-### 2. **Touch and Drag Support**
-The component supports touch gestures on mobile and drag events on desktop for smooth navigation.
+### 2. **Touch, Drag, and Keyboard Support**
+Supports touch gestures, mouse dragging, and keyboard navigation (Arrow keys, Home/End).
 
 ### 3. **Dynamic Adjustments**
-The slider dynamically adjusts the width of slides to match the container's size, ensuring responsiveness.
+Dynamically adjusts slide widths and offsets on window resize (debounced for performance).
 
-### 4. **Keyboard Navigation**
-The component listens for click events on `prev` and `next` buttons, enabling navigation through slides.
+### 4. **Accessibility**
+Announces slide changes, manages focus, and sets ARIA attributes for slides and navigation.
+
+### 5. **Single Slide Handling**
+If only one slide is present, navigation controls are removed and the slide is centered.
+
+### 6. **Custom Events**
+Dispatches a `slideChange` event on slide change with details about the current slide.
 
 ---
 
 ## Usage
-
-Here’s an example of how to use the `IRNMNSlider` component in your HTML:
 
 ```html
 <irnmn-slider selectors='{
@@ -106,9 +117,20 @@ Here’s an example of how to use the `IRNMNSlider` component in your HTML:
 
 ---
 
+## Features
+
+- **Looping:** Clones slides for seamless infinite navigation.
+- **Swipe & Drag:** Touch and mouse drag support.
+- **Keyboard Navigation:** Arrow keys, Home/End, focus management.
+- **Accessibility:** ARIA roles, live region, focus handling, clones hidden from screen readers.
+- **Responsive:** Adjusts slide widths and offsets on resize.
+- **Custom Events:** Dispatches `slideChange` event on slide change.
+- **Debugging:** Add `?debugTracking=true` to the URL for console logs.
+
+---
+
 ## Example Selectors
 
-### Default Selectors:
 ```json
 {
     "SWIPE_CONTAINER": "wp-block-custom21c-gallery--images",
@@ -123,16 +145,10 @@ Here’s an example of how to use the `IRNMNSlider` component in your HTML:
 
 ---
 
-## Features
+## Notes
 
-### **1. Looping**
-The component clones the first and last slides to create a seamless looping effect.
+- If only one slide is present, navigation controls are removed and the slide is centered.
+- For debugging, add `?debugTracking=true` to the URL to enable console logs.
+- To refresh the slider after dynamic content changes, call the `refresh()` method.
+- All event listeners are cleaned up automatically when the component is removed from the DOM.
 
-### **2. Swipe and Drag**
-Supports swipe gestures on touch devices and mouse dragging for desktop users.
-
-### **3. Pagination**
-Dynamically updates the pagination indicator to reflect the current slide.
-
-### **4. Resizable**
-Automatically adjusts the width of slides when the window resizes.

--- a/slider/readme.md
+++ b/slider/readme.md
@@ -80,13 +80,13 @@ Here’s an example of how to use the `IRNMNSlider` component in your HTML:
 
 ```html
 <irnmn-slider selectors='{
-    "SWIPE_CONTAINER": "slider-container",
-    "SLIDES": "slider-slide",
-    "NAVIGATION": "slider-navigation",
-    "PREV_BUTTON": "slider-prev",
-    "NEXT_BUTTON": "slider-next",
-    "CURRENT_SLIDE": "current-slide",
-    "TOTAL_SLIDES": "total-slides"
+    "SWIPE_CONTAINER": ".slider-container",
+    "SLIDES": ".slider-slide",
+    "NAVIGATION": ".slider-navigation",
+    "PREV_BUTTON": ".slider-prev",
+    "NEXT_BUTTON": ".slider-next",
+    "CURRENT_SLIDE": ".current-slide",
+    "TOTAL_SLIDES": ".total-slides"
 }'>
     <div class="slider-container">
         <div class="slider-slide">Slide 1</div>
@@ -96,7 +96,7 @@ Here’s an example of how to use the `IRNMNSlider` component in your HTML:
     <div class="slider-navigation">
         <button class="slider-prev">Previous</button>
         <span>
-            <span class="current-slide">1</span> / 
+            <span class="current-slide">1</span> /
             <span class="total-slides">3</span>
         </span>
         <button class="slider-next">Next</button>

--- a/slider/readme.md
+++ b/slider/readme.md
@@ -34,7 +34,43 @@ The `IRNMNSlider` web component is a dynamic, accessible, and responsive slider 
 - Adds an `aria-live` region for announcing slide changes.
 - Sets ARIA roles and labels for slides and navigation.
 - Keyboard navigation: supports Arrow keys, Home/End, and focus management.
-- Cloned slides are hidden from assistive technologies.
+- Cloned slides are hidden from assistive technologies to ensure a clean experience for screen reader users.
+- While the component provides fallback ARIA labels, it is best practice to set meaningful ARIA attributes directly in your HTML for proper localization and translation. For example:
+
+```html
+<irnmn-slider debug selectors='{
+    "SWIPE_CONTAINER": ".slider-container",
+    "SLIDES": ".slider-slide",
+    "NAVIGATION": ".slider-navigation",
+    "PREV_BUTTON": ".slider-prev",
+    "NEXT_BUTTON": ".slider-next",
+    "CURRENT_SLIDE": ".current-slide",
+    "TOTAL_SLIDES": ".total-slides"
+}'>
+    <div class="slider-container" aria-label="My Deluxe room image slider with 4 slides">
+        <div class="slider-slide" aria-label="First slide of four">
+            <img src="..." alt="Image description" />
+        </div>
+        <div class="slider-slide" aria-label="Second slide of four">
+            <img src="..." alt="Image description" />
+        </div>
+        <div class="slider-slide" aria-label="Third slide of four">
+            <img src="..." alt="Image description" />
+        </div>
+        <div class="slider-slide" aria-label="Fourth slide of four">
+            <img src="..." alt="Image description" />
+        </div>
+    </div>
+    <div class="slider-navigation">
+        <button class="slider-prev" aria-label="Go to previous slide">Previous</button>
+        <span>
+            <span class="current-slide">1</span> /
+            <span class="total-slides">4</span>
+        </span>
+        <button class="slider-next" aria-label="Go to next slide">Next</button>
+    </div>
+</irnmn-slider>
+```
 
 ---
 
@@ -126,22 +162,6 @@ Dispatches a `slideChange` event on slide change with details about the current 
 - **Responsive:** Adjusts slide widths and offsets on resize.
 - **Custom Events:** Dispatches `slideChange` event on slide change.
 - **Debugging:** Add `?debugTracking=true` to the URL for console logs.
-
----
-
-## Example Selectors
-
-```json
-{
-    "SWIPE_CONTAINER": "wp-block-custom21c-gallery--images",
-    "SLIDES": "wp-block-custom21c-gallery--image",
-    "NAVIGATION": "slideshow-navigation",
-    "PREV_BUTTON": "prev",
-    "NEXT_BUTTON": "next",
-    "CURRENT_SLIDE": "current-slide",
-    "TOTAL_SLIDES": "total-slides"
-}
-```
 
 ---
 

--- a/slider/style.css
+++ b/slider/style.css
@@ -1,0 +1,33 @@
+
+irnmn-slider{
+    overflow: hidden;
+    width: 100%;
+    display: block;
+    position: relative;
+    padding-bottom: 50px;
+}
+
+irnmn-slider .slider-container {
+    display: flex;
+    transition: transform 0.3s ease;
+    width: 100%;
+}
+
+irnmn-slider .slider-slide {
+    flex-shrink: 0;
+    margin: 0;
+    width: 100%; /* Each slide takes full container width */
+    height: 100px; /* Fixed height for the slider */
+    cursor: grab;
+    padding: 0;
+}
+
+irnmn-slider .slider-navigation {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+    justify-content: center;
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+}

--- a/stories/Slider.stories.ts
+++ b/stories/Slider.stories.ts
@@ -17,7 +17,7 @@ const meta: Meta<IRNMNSlider> = {
     },
     render: (args) => {
         return html`
-        <irnmn-slider selectors='{
+        <irnmn-slider debug selectors='{
             "SWIPE_CONTAINER": ".slider-container",
             "SLIDES": ".slider-slide",
             "NAVIGATION": ".slider-navigation",

--- a/stories/Slider.stories.ts
+++ b/stories/Slider.stories.ts
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import {html} from "lit";
+import IRNMNSlider from "../slider";
+import readme from '../slider/readme.md?raw';
+import '../slider/style.css';
+
+const meta: Meta<IRNMNSlider> = {
+    title: 'Components/Slider',
+    tags: ['autodocs'],
+    component: 'irnmn-slider',
+    parameters: {
+        docs: {
+            description: {
+            component: readme,
+            },
+        },
+    },
+    render: (args) => {
+        return html`
+        <irnmn-slider selectors='{
+            "SWIPE_CONTAINER": ".slider-container",
+            "SLIDES": ".slider-slide",
+            "NAVIGATION": ".slider-navigation",
+            "PREV_BUTTON": ".slider-prev",
+            "NEXT_BUTTON": ".slider-next",
+            "CURRENT_SLIDE": ".current-slide",
+            "TOTAL_SLIDES": ".total-slides"
+        }'>
+            <div class="slider-container">
+                <div class="slider-slide" style="background-color:yellow; justify-content:center; display:flex; align-items:center;"><b>SLIDE #1</b></div>
+                <div class="slider-slide" style="background-color:red; justify-content:center; display:flex; align-items:center;"><b>SLIDE #2</b></div>
+                <div class="slider-slide" style="background-color:blue; justify-content:center; display:flex; align-items:center;"><b>SLIDE #3</b></div>
+                <div class="slider-slide" style="background-color:green; justify-content:center; display:flex; align-items:center;"><b>SLIDE #4</b></div>
+            </div>
+            <div class="slider-navigation">
+                <button class="slider-prev">Previous</button>
+                <span>
+                    <span class="current-slide">1</span> /
+                    <span class="total-slides">3</span>
+                </span>
+                <button class="slider-next">Next</button>
+            </div>
+        </irnmn-slider>
+        `;
+    }
+}
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
Accessibility & Usability Enhancements to <irnmn-slider>

Key improvements:
- Implemented full keyboard navigation support (←, →, Home, End)
- Added ARIA roles and descriptions:
- role="region" and aria-roledescription="carousel" on container
- role="group" and aria-roledescription="slide" on real slides
- Added live region (aria-live="polite") to announce slide changes
- Managed tabindex dynamically to restrict focus to the active slide only
- Ensured cloned slides are marked with aria-hidden="true" and excluded from tab order
- Added aria-controls and aria-label to navigation buttons
- Preserved focus behavior after navigation (keyboard and swipe)
- Centralized accessibility logic via initSlidesAttributes() and updateSlidesAttributes()
- Improved resetPosition() to return focus only when interaction originated from within a slide

@wpagencymatt I added you as a reviewer as you might spot something I missed on accessibility :)