### PR TITLE
Fix/irnmn 3702/redirect modal fix

### DIFF
--- a/booking-popup/index.js
+++ b/booking-popup/index.js
@@ -25,7 +25,6 @@ class IRNMNBookingModal extends IRNMNPopup {
         return this.getAttribute('form-id') || null;
     }
 
-
     /**
      * Retrieves whether the modal should be shown based on the 'has-modal' attribute.
      * @returns {boolean} True if the modal is enabled, false otherwise.
@@ -153,7 +152,6 @@ class IRNMNBookingModal extends IRNMNPopup {
         const modal = this.querySelector('.irnmn-modal');
         if (modal) this.showModal(modal);
     }
-
 
     closeModal() {
         super.closeModal();

--- a/booking-popup/index.js
+++ b/booking-popup/index.js
@@ -15,7 +15,6 @@ class IRNMNBookingModal extends IRNMNPopup {
      */
     constructor() {
         super();
-        this.timerInterval = null; // Stores the reference to the timer interval for clearing it later
     }
 
     /**
@@ -26,14 +25,6 @@ class IRNMNBookingModal extends IRNMNPopup {
         return this.getAttribute('form-id') || null;
     }
 
-    /**
-     * Retrieves and validates the timer value from the component's attributes.
-     * @returns {number|false} The timer value as a positive integer or false if invalid.
-     */
-    get timer() {
-        const timer = parseInt(this.getAttribute('modal-timer'), 10);
-        return isNaN(timer) || timer <= 0 ? false : timer;
-    }
 
     /**
      * Retrieves whether the modal should be shown based on the 'has-modal' attribute.
@@ -85,7 +76,7 @@ class IRNMNBookingModal extends IRNMNPopup {
 
     /**
      * Called when the element is removed from the DOM.
-     * Ensures event listeners and timers are properly cleared.
+     * Ensures event listeners are properly removed.
      */
     disconnectedCallback() {
         if (this.form) {
@@ -94,7 +85,6 @@ class IRNMNBookingModal extends IRNMNPopup {
                 this.handleBookingModal.bind(this),
             );
         }
-        this.stopTimer();
         super.disconnectedCallback();
     }
 
@@ -103,7 +93,6 @@ class IRNMNBookingModal extends IRNMNPopup {
         return [
             ...(super.observedAttributes || []),
             'has-modal',
-            'modal-timer',
             'form-id',
             'form-need-validation',
         ];
@@ -163,41 +152,11 @@ class IRNMNBookingModal extends IRNMNPopup {
         e.preventDefault();
         const modal = this.querySelector('.irnmn-modal');
         if (modal) this.showModal(modal);
-
-        if (this.timer) this.startTimer();
     }
 
-    /**
-     * Starts a countdown timer which triggers form submission upon completion.
-     */
-    startTimer() {
-        const timerElement = this.querySelector('.modal-timer');
-
-        let timeLeft = this.timer;
-        this.timerInterval = setInterval(() => {
-            timeLeft -= 1;
-            if (timerElement) timerElement.textContent = timeLeft;
-
-            if (timeLeft <= 0) {
-                this.stopTimer();
-                this.form.submit();
-            }
-        }, 1000);
-    }
-
-    /**
-     * Stops the countdown timer and clears the interval reference.
-     */
-    stopTimer() {
-        if (this.timerInterval) {
-            clearInterval(this.timerInterval);
-            this.timerInterval = null;
-        }
-    }
 
     closeModal() {
         super.closeModal();
-        this.stopTimer();
     }
 }
 if (!customElements.get('irnmn-booking-modal')) {

--- a/booking-popup/index.js
+++ b/booking-popup/index.js
@@ -107,6 +107,7 @@ class IRNMNBookingModal extends IRNMNPopup {
         const modal = this.querySelector('.irnmn-modal');
         if (!modal) return;
 
+        // target all wordpress buttons within the modal and use the last one as continue button to allow user to proceed
         const wpButtons = modal.querySelectorAll('.wp-block-button a');
         const continueButton = wpButtons[wpButtons.length - 1] || false;
 

--- a/booking-popup/index.js
+++ b/booking-popup/index.js
@@ -140,11 +140,18 @@ class IRNMNBookingModal extends IRNMNPopup {
 
         // Check if the modal can be shown and log warnings/errors for each case
         if (!this.hasModal) {
-            console.warn('[Booking Modal Warning]: has-modal attribute is not enabled.');
+            console.warn(
+                '[Booking Modal Warning]: has-modal attribute is not enabled.',
+            );
             return;
         }
-        if (this.formNeedValidation && this.form.getAttribute('valid') === null) {
-            console.warn('[Booking Modal Warning]: Form validation required and form is not valid.');
+        if (
+            this.formNeedValidation &&
+            this.form.getAttribute('valid') === null
+        ) {
+            console.warn(
+                '[Booking Modal Warning]: Form validation required and form is not valid.',
+            );
             return;
         }
         if (!modal) {
@@ -152,11 +159,16 @@ class IRNMNBookingModal extends IRNMNPopup {
             return;
         }
         if (this.content === null || this.content.trim() === '') {
-            console.error('[Booking Modal Error]: Modal content is missing : null or empty', this.content);
+            console.error(
+                '[Booking Modal Error]: Modal content is missing : null or empty',
+                this.content,
+            );
             return;
         }
         if (!this.hasContinueButton) {
-            console.error('[Booking Modal Error]: Continue button not found in modal.');
+            console.error(
+                '[Booking Modal Error]: Continue button not found in modal.',
+            );
             return;
         }
 


### PR DESCRIPTION
https://ennismore.atlassian.net/browse/IRNMN-3702

	•	Bind submit handler once (this._onSubmit) so listeners are added/removed correctly.
	•	Gate modal display behind has-modal and optional form validation; fall back to normal submit otherwise (no preventDefault).
	•	Validate content via this.content (empty/null → skip modal) and require a CTA; both cases log clear console errors.
	•	On render, locate CTA (.wp-block-button a), set hasContinueButton, and attach click/keydown handlers to submit the form from the modal.
	•	Keep normal redirect behavior when modal is invalid or missing, preventing empty/blocked popups.
	•	Remove unused timer logic