### PR TITLE
Release/v1.3.7

### DIFF
--- a/location/index.js
+++ b/location/index.js
@@ -14,7 +14,7 @@ class IRNMNLocation extends HTMLElement {
     }
 
     static get observedAttributes() {
-        return ['show-error'];
+        return ['show-error', 'default'];
     }
 
     /**
@@ -27,6 +27,11 @@ class IRNMNLocation extends HTMLElement {
     attributeChangedCallback(name, oldValue, newValue) {
         if (name === 'show-error' && oldValue !== newValue) {
             this.renderErrorMessage();
+        }
+        if(name === 'default' && oldValue !== newValue) {
+            // This is probably not the most ideal solution, but not sure how else to propagate
+            // 'default' change to irnmn-select
+            this.render();
         }
     }
 

--- a/select/index.js
+++ b/select/index.js
@@ -144,7 +144,7 @@ class IrnmnSelect extends HTMLElement {
                             : ``
                     }
                     <div class="${CLASS_NAMES.header} ${this.selectedOption !== null ? CLASS_NAMES.header + '--selected' : ''}" tabindex="0" role="combobox" aria-expanded="${this.isOpen}" aria-haspopup="listbox" ${this.labelId ? `aria-labelledby="${this.labelId}"` : ''}>
-                        ${this.selectedOption !== null ? this.options[this.selectedOption].name : this.headingText}
+                        ${this.selectedOption !== null ? this.options[this.selectedOption].name : this.placeholder}
                     </div>
                     <ul class="${CLASS_NAMES.list} ${this.isOpen ? CLASS_NAMES.listOpen : ''}" role="listbox">
                     ${


### PR DESCRIPTION
- Location component now displays placeholder value instead of heading text for the placeholder
- [#3676](https://ennismore.atlassian.net/browse/IRNMN-3676) - `default` attribute on Location component can now be set from outside the component and it will trigger a re-render of the component; used at the Hoxton