### PR TITLE
chore: upgrade GitHub Actions to Node.js 20/24 compatible versions

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: 20
 


### PR DESCRIPTION
## Summary

- Upgrade GitHub Actions to Node.js 20/24 compatible versions
- Resolves GitHub annotation warnings about deprecated Node.js 12/16 runtimes
- Updated: `actions/checkout` → v6.0.2, `actions/setup-node` → v6.3.0, `actions/setup-go` → v6.3.0, `actions/cache` → v5.0.3, `actions/upload-artifact` → v7.0.0, `actions/download-artifact` → v8.0.1, `aws-actions/configure-aws-credentials` → v6.0.0, `PaulHatch/semantic-version` → v6.0.1, `docker/*` actions, and others

**Reference:** https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/