### PR TITLE
feat/IRNMN-3307: moved room card description to be above book button

### DIFF
--- a/room-card/index.js
+++ b/room-card/index.js
@@ -559,8 +559,8 @@ class IrnmnRoomCard extends HTMLElement {
                 <div class="room-card__content">
                     <h2 class="room-card__title">${this.title}</h2>
                     ${this.renderExtras(true)}
-                    ${roomPricingHTML}
                     <p class="room-card__description">${this.description}</p>
+                    ${roomPricingHTML}
                 </div>
             </div>
 


### PR DESCRIPTION
Move room card description above Book button on 1 column layout
https://ennismore.atlassian.net/browse/IRNMN-4687

What

Moved the room card description to be above the Book button

How

Swapped the order of elements in the component definition

How to test

Not necessary to test locally, but if you really want to:
- pull `feat/IRNMN-3307/move-description` for irnmn-components
- link it locally to `irnmn-parent` theme or change it in package.json
- either create or find a page with a one column layout room card
- make sure description is above the Book button

Test deployed at: https://ennismore-develop.go-vip.net/mondrian/singapore-duxton/rooms-suites/shophouse/

PR Checklist

- [x] Have you checked the base branch is correct for this PR?
- [x] Have you added a short description of the issue and the changes?
- [x] Have you linked a JIRA ticket to this PR?
- [x] Have you made it clear what you want the reviewer to focus on?
- [x] Have you listed the steps needed to test locally?
- [x] Does the code being changed match with the A/C listed in the linked JIRA ticket?
- [ ] Have you uploaded additional resources like a xml file to help with local testing?
- [ ] Have you added documentation to the changes if needed?
- [ ] Have you sensed checked the changes against co-pilot or other LLM?