### PR TITLE
Feat/irnmn 4661/child age defaults

### DIFF
--- a/guests-selector/index.js
+++ b/guests-selector/index.js
@@ -266,6 +266,7 @@ class IRNMNGuestsSelector extends HTMLElement {
             ariaLabelLessAdults: 'Remove one adult',
             ariaLabelMoreChildren: 'Add one child',
             ariaLabelLessChildren: 'Remove one child',
+            childAgeValidation: 'Please select a child age'
         };
         const customLabels = JSON.parse(this.getAttribute('labels')) || {};
         return { ...defaultLabels, ...customLabels };
@@ -481,18 +482,17 @@ class IRNMNGuestsSelector extends HTMLElement {
                 'name',
                 `${this.name}.childrenAges[${i - 1}]`,
             );
-            if(this.childAgePreselected === 'false') ageDropdown.setAttribute('required', true);
+            if (this.childAgePreselected === 'false') ageDropdown.setAttribute('required', true);
             ageDropdown.innerHTML = this.generateAgeOptions(this.maxChildAge);
 
             // Initialize childrenAges[i - 1] to 1 if not already set
             if (!this.state.childrenAges[i - 1]) {
-                if(this.childAgePreselected === 'true') {
+                if (this.childAgePreselected === 'true') {
                     this.state.childrenAges[i - 1] = 1; // Set default age to 1
                 } else {
-                    this.state.childrenAges[i - 1] = ""; // Set the age to be an empty string which will match the placeholder
+                    this.state.childrenAges[i - 1] = ''; // Set the age to be an empty string which will match the placeholder
                 }
             }
-
 
             ageDropdown.value = this.state.childrenAges[i - 1]; // Set the dropdown value to the initialized age
 
@@ -524,17 +524,18 @@ class IRNMNGuestsSelector extends HTMLElement {
             // create a label for the child age select
             const label = document.createElement('label');
             label.textContent = `${this.labels.childAge} (${i})`;
+            // Appends * if this field is required
+            if(this.childAgePreselected === 'false') label.textContent += '*';
             // create a wrapper for label and select
             const ageWrapper = document.createElement('div');
             ageWrapper.classList.add(CLASS_NAMES.childAgeWrapper);
             ageWrapper.appendChild(label);
 
-
             // Adding the error message so the validation script in irnmn-parent can validate these fields
-            if(this.childAgePreselected === 'false') {
+            if (this.childAgePreselected === 'false') {
                 ageWrapper.setAttribute(
                     'error-message',
-                    'Please select a child age',
+                    this.labels.childAgeValidation,
                 );
                 ageWrapper.setAttribute('show-error', false);
             }
@@ -572,7 +573,8 @@ class IRNMNGuestsSelector extends HTMLElement {
         let options = '';
         console.log('generate age options');
 
-        if(this.childAgePreselected === 'false') options += `<option value="">Select</option>`;
+        if (this.childAgePreselected === 'false')
+            options += `<option value="">Select</option>`;
 
         for (let i = 1; i <= maxAge; i++) {
             options += `<option value="${i}">${i}</option>`;

--- a/guests-selector/index.js
+++ b/guests-selector/index.js
@@ -38,8 +38,8 @@ class IRNMNGuestsSelector extends HTMLElement {
 
         this.errorObserver = this.createErrorObserver();
         this.errorObserverConfig = {
-            attributes: true
-        }
+            attributes: true,
+        };
     }
 
     static get observedAttributes() {
@@ -51,20 +51,18 @@ class IRNMNGuestsSelector extends HTMLElement {
             'children-number',
             'max-child-age',
             'enable-children',
-            'enable-children-ages'
+            'enable-children-ages',
         ];
     }
 
     createErrorObserver(element) {
-
         return new MutationObserver((mutationList) => {
             for (const mutation of mutationList) {
-                const ErrorState = mutation.target.getAttribute("show-error");
+                const ErrorState = mutation.target.getAttribute('show-error');
                 const PreviousState = mutation.oldValue;
-                if(ErrorState != PreviousState) {
+                if (ErrorState != PreviousState) {
                     this.renderErrorMessage(mutation.target, ErrorState);
                 }
-
             }
         });
     }
@@ -72,11 +70,14 @@ class IRNMNGuestsSelector extends HTMLElement {
     observeChildAgeSelectors() {
         //console.log("observeChildAgeSelectors()");
         // Making sure this exists, if it doesn't create it
-        if(this.errorObserver == null) this.errorObserver = this.createErrorObserver();
+        if (this.errorObserver == null)
+            this.errorObserver = this.createErrorObserver();
 
-        const ChildAgeSelectors = this.querySelectorAll(`.${CLASS_NAMES.childAgeWrapper}`);
+        const ChildAgeSelectors = this.querySelectorAll(
+            `.${CLASS_NAMES.childAgeWrapper}`,
+        );
 
-        Array.from(ChildAgeSelectors).forEach(element => {
+        Array.from(ChildAgeSelectors).forEach((element) => {
             this.errorObserver.observe(element, this.errorObserverConfig);
         });
     }
@@ -114,7 +115,7 @@ class IRNMNGuestsSelector extends HTMLElement {
         this.enableChildrenAges = this.getEnableChildrenAges();
         this.maxChildAge = this.getMaxChildAge();
         this.maxGuestsLabel = this.getMaxGuestsLabel();
-        this.childrenDefaultAge = this.getChildDefaultAge();
+        this.childAgePreselected = this.getChildAgePreselected();
     }
 
     updateState() {
@@ -181,15 +182,11 @@ class IRNMNGuestsSelector extends HTMLElement {
     }
 
     /**
-     * Get the child default age clamped value between 0-{maxChildAge} or -1 if the attribute doesn't exist or not a number
-     * @return {Number} Returns the age or -1 if invalid
+     * Get the child pre-selected attribute value
+     * @return {Boolean} Returns the age or -1 if invalid
      */
-    getChildDefaultAge() {
-        const ChildDefaultAge = parseInt(this.getAttribute('child-default-age')) || -1;
-        if(ChildDefaultAge < 1) return ChildDefaultAge;
-
-        const ClampedChildDefaultAge = Math.min(Math.max(ChildDefaultAge, 0), this.maxChildAge);
-        return ClampedChildDefaultAge;
+    getChildAgePreselected() {
+        return this.getAttribute('child-age-preselected') || true;
     }
 
     /**
@@ -300,29 +297,24 @@ class IRNMNGuestsSelector extends HTMLElement {
      * @return {Element} Element for the child age dropdowns
      */
     getChildAgeContainerElement() {
-        return this.querySelector(
-            `.${CLASS_NAMES.childrenAgeDropdowns}`,
-        );
+        return this.querySelector(`.${CLASS_NAMES.childrenAgeDropdowns}`);
     }
-
 
     // Created or removes the error message for a given element
     renderErrorMessage(element, errorState) {
-        if(errorState === 'true') {
+        if (errorState === 'true') {
             // If the element already exist we don't create it again
-            if(!element?.querySelector(`.${CLASS_NAMES.errorMessage}`)) {
-                const ErrorMessage = element.getAttribute("error-message");
+            if (!element?.querySelector(`.${CLASS_NAMES.errorMessage}`)) {
+                const ErrorMessage = element.getAttribute('error-message');
                 const errorMessageElement = document.createElement('div');
                 errorMessageElement.classList.add(CLASS_NAMES.errorMessage);
                 errorMessageElement.textContent = ErrorMessage;
                 element.appendChild(errorMessageElement);
             }
-
         } else {
             // Remove it if it exists
             element?.querySelector(`.${CLASS_NAMES.errorMessage}`)?.remove();
         }
-
     }
 
     render() {
@@ -482,7 +474,6 @@ class IRNMNGuestsSelector extends HTMLElement {
         const childAgeContainer = this.getChildAgeContainerElement();
         childAgeContainer.innerHTML = ''; // Clear existing dropdowns
 
-
         for (let i = 1; i <= this.state.children; i++) {
             const ageDropdown = document.createElement('select');
             ageDropdown.setAttribute('id', `irnmn-child-age-${i}`);
@@ -490,15 +481,20 @@ class IRNMNGuestsSelector extends HTMLElement {
                 'name',
                 `${this.name}.childrenAges[${i - 1}]`,
             );
-            ageDropdown.setAttribute("required", true);
+            if(this.childAgePreselected === 'false') ageDropdown.setAttribute('required', true);
             ageDropdown.innerHTML = this.generateAgeOptions(this.maxChildAge);
 
             // Initialize childrenAges[i - 1] to 1 if not already set
             if (!this.state.childrenAges[i - 1]) {
-                this.state.childrenAges[i - 1] = 1; // Set default age to 1
+                if(this.childAgePreselected === 'true') {
+                    this.state.childrenAges[i - 1] = 1; // Set default age to 1
+                } else {
+                    this.state.childrenAges[i - 1] = ""; // Set the age to be an empty string which will match the placeholder
+                }
             }
 
-            //ageDropdown.value = this.state.childrenAges[i - 1]; // Set the dropdown value to the initialized age
+
+            ageDropdown.value = this.state.childrenAges[i - 1]; // Set the dropdown value to the initialized age
 
             // Dispatch event on change
             ageDropdown.addEventListener('change', () => {
@@ -506,9 +502,14 @@ class IRNMNGuestsSelector extends HTMLElement {
                 this.state.childrenAges[i - 1] = Value;
 
                 // If the error is shown and we selected a valid value we'll remove the error message.
-                const ParentElement = ageDropdown.closest(`.${CLASS_NAMES.childAgeWrapper}`);
-                if(ParentElement?.getAttribute("show-error") === 'true' && !isNaN(Value)) {
-                    ParentElement.setAttribute("show-error", false);
+                const ParentElement = ageDropdown.closest(
+                    `.${CLASS_NAMES.childAgeWrapper}`,
+                );
+                if (
+                    ParentElement?.getAttribute('show-error') === 'true' &&
+                    !isNaN(Value)
+                ) {
+                    ParentElement.setAttribute('show-error', false);
                     //this.renderErrorMessage(ParentElement, false);
                 }
 
@@ -520,9 +521,6 @@ class IRNMNGuestsSelector extends HTMLElement {
                 );
             });
 
-
-
-
             // create a label for the child age select
             const label = document.createElement('label');
             label.textContent = `${this.labels.childAge} (${i})`;
@@ -530,9 +528,17 @@ class IRNMNGuestsSelector extends HTMLElement {
             const ageWrapper = document.createElement('div');
             ageWrapper.classList.add(CLASS_NAMES.childAgeWrapper);
             ageWrapper.appendChild(label);
+
+
             // Adding the error message so the validation script in irnmn-parent can validate these fields
-            ageWrapper.setAttribute("error-message", "Please select a child age");
-            ageWrapper.setAttribute("show-error",false);
+            if(this.childAgePreselected === 'false') {
+                ageWrapper.setAttribute(
+                    'error-message',
+                    'Please select a child age',
+                );
+                ageWrapper.setAttribute('show-error', false);
+            }
+
             // create a wrapper for label and select
             const selectWrapper = document.createElement('div');
             selectWrapper.classList.add('irnmn-child-age-select-wrapper');
@@ -564,9 +570,9 @@ class IRNMNGuestsSelector extends HTMLElement {
 
     generateAgeOptions(maxAge) {
         let options = '';
-        console.log("generate age options");
+        console.log('generate age options');
 
-        options += `<option value="">Select</option>`;
+        if(this.childAgePreselected === 'false') options += `<option value="">Select</option>`;
 
         for (let i = 1; i <= maxAge; i++) {
             options += `<option value="${i}">${i}</option>`;

--- a/guests-selector/index.js
+++ b/guests-selector/index.js
@@ -68,7 +68,6 @@ class IRNMNGuestsSelector extends HTMLElement {
     }
 
     observeChildAgeSelectors() {
-        //console.log("observeChildAgeSelectors()");
         // Making sure this exists, if it doesn't create it
         if (this.errorObserver == null)
             this.errorObserver = this.createErrorObserver();
@@ -183,10 +182,11 @@ class IRNMNGuestsSelector extends HTMLElement {
 
     /**
      * Get the child pre-selected attribute value
-     * @return {Boolean} Returns the age or -1 if invalid
+     * @return {Boolean} Returns the value of the attribute or true
      */
     getChildAgePreselected() {
-        return this.getAttribute('child-age-preselected') || true;
+        const childAgePreselectedAttr = this.getAttribute('child-age-preselected') || true;
+        return  childAgePreselectedAttr === 'true' || childAgePreselectedAttr === true;
     }
 
     /**
@@ -266,7 +266,7 @@ class IRNMNGuestsSelector extends HTMLElement {
             ariaLabelLessAdults: 'Remove one adult',
             ariaLabelMoreChildren: 'Add one child',
             ariaLabelLessChildren: 'Remove one child',
-            childAgeValidation: 'Please select a child age'
+            childAgeValidation: 'Please select a child age',
         };
         const customLabels = JSON.parse(this.getAttribute('labels')) || {};
         return { ...defaultLabels, ...customLabels };
@@ -482,12 +482,12 @@ class IRNMNGuestsSelector extends HTMLElement {
                 'name',
                 `${this.name}.childrenAges[${i - 1}]`,
             );
-            if (this.childAgePreselected === 'false') ageDropdown.setAttribute('required', true);
+            if (this.childAgePreselected === false) ageDropdown.setAttribute('required', true);
             ageDropdown.innerHTML = this.generateAgeOptions(this.maxChildAge);
 
             // Initialize childrenAges[i - 1] to 1 if not already set
             if (!this.state.childrenAges[i - 1]) {
-                if (this.childAgePreselected === 'true') {
+                if (this.childAgePreselected === true) {
                     this.state.childrenAges[i - 1] = 1; // Set default age to 1
                 } else {
                     this.state.childrenAges[i - 1] = ''; // Set the age to be an empty string which will match the placeholder
@@ -525,14 +525,14 @@ class IRNMNGuestsSelector extends HTMLElement {
             const label = document.createElement('label');
             label.textContent = `${this.labels.childAge} (${i})`;
             // Appends * if this field is required
-            if(this.childAgePreselected === 'false') label.textContent += '*';
+            if (this.childAgePreselected === false) label.textContent += '*';
             // create a wrapper for label and select
             const ageWrapper = document.createElement('div');
             ageWrapper.classList.add(CLASS_NAMES.childAgeWrapper);
             ageWrapper.appendChild(label);
 
             // Adding the error message so the validation script in irnmn-parent can validate these fields
-            if (this.childAgePreselected === 'false') {
+            if (this.childAgePreselected === false) {
                 ageWrapper.setAttribute(
                     'error-message',
                     this.labels.childAgeValidation,
@@ -571,9 +571,8 @@ class IRNMNGuestsSelector extends HTMLElement {
 
     generateAgeOptions(maxAge) {
         let options = '';
-        console.log('generate age options');
 
-        if (this.childAgePreselected === 'false')
+        if (this.childAgePreselected === false)
             options += `<option value="">Select</option>`;
 
         for (let i = 1; i <= maxAge; i++) {

--- a/guests-selector/index.js
+++ b/guests-selector/index.js
@@ -35,6 +35,11 @@ class IRNMNGuestsSelector extends HTMLElement {
                 childrenAges: [],
             };
         }
+
+        this.errorObserver = this.createErrorObserver();
+        this.errorObserverConfig = {
+            attributes: true
+        }
     }
 
     static get observedAttributes() {
@@ -46,8 +51,34 @@ class IRNMNGuestsSelector extends HTMLElement {
             'children-number',
             'max-child-age',
             'enable-children',
-            'enable-children-ages',
+            'enable-children-ages'
         ];
+    }
+
+    createErrorObserver(element) {
+
+        return new MutationObserver((mutationList) => {
+            for (const mutation of mutationList) {
+                const ErrorState = mutation.target.getAttribute("show-error");
+                const PreviousState = mutation.oldValue;
+                if(ErrorState != PreviousState) {
+                    this.renderErrorMessage(mutation.target, ErrorState);
+                }
+
+            }
+        });
+    }
+
+    observeChildAgeSelectors() {
+        //console.log("observeChildAgeSelectors()");
+        // Making sure this exists, if it doesn't create it
+        if(this.errorObserver == null) this.errorObserver = this.createErrorObserver();
+
+        const ChildAgeSelectors = this.querySelectorAll(`.${CLASS_NAMES.childAgeWrapper}`);
+
+        Array.from(ChildAgeSelectors).forEach(element => {
+            this.errorObserver.observe(element, this.errorObserverConfig);
+        });
     }
 
     attributeChangedCallback(name, oldValue, newValue) {
@@ -83,6 +114,7 @@ class IRNMNGuestsSelector extends HTMLElement {
         this.enableChildrenAges = this.getEnableChildrenAges();
         this.maxChildAge = this.getMaxChildAge();
         this.maxGuestsLabel = this.getMaxGuestsLabel();
+        this.childrenDefaultAge = this.getChildDefaultAge();
     }
 
     updateState() {
@@ -146,6 +178,18 @@ class IRNMNGuestsSelector extends HTMLElement {
                 enableChildrenAttr !== 'null' &&
                 enableChildrenAttr)
         );
+    }
+
+    /**
+     * Get the child default age clamped value between 0-{maxChildAge} or -1 if the attribute doesn't exist or not a number
+     * @return {Number} Returns the age or -1 if invalid
+     */
+    getChildDefaultAge() {
+        const ChildDefaultAge = parseInt(this.getAttribute('child-default-age')) || -1;
+        if(ChildDefaultAge < 1) return ChildDefaultAge;
+
+        const ClampedChildDefaultAge = Math.min(Math.max(ChildDefaultAge, 0), this.maxChildAge);
+        return ClampedChildDefaultAge;
     }
 
     /**
@@ -249,6 +293,36 @@ class IRNMNGuestsSelector extends HTMLElement {
         return enableMaxGuestsLabel == 'true'
             ? `(max ${this.maxTotalGuests} ${this.labels.guests})`
             : ``;
+    }
+
+    /**
+     * Get the wrapper element for the child age dropdowns
+     * @return {Element} Element for the child age dropdowns
+     */
+    getChildAgeContainerElement() {
+        return this.querySelector(
+            `.${CLASS_NAMES.childrenAgeDropdowns}`,
+        );
+    }
+
+
+    // Created or removes the error message for a given element
+    renderErrorMessage(element, errorState) {
+        if(errorState === 'true') {
+            // If the element already exist we don't create it again
+            if(!element?.querySelector(`.${CLASS_NAMES.errorMessage}`)) {
+                const ErrorMessage = element.getAttribute("error-message");
+                const errorMessageElement = document.createElement('div');
+                errorMessageElement.classList.add(CLASS_NAMES.errorMessage);
+                errorMessageElement.textContent = ErrorMessage;
+                element.appendChild(errorMessageElement);
+            }
+
+        } else {
+            // Remove it if it exists
+            element?.querySelector(`.${CLASS_NAMES.errorMessage}`)?.remove();
+        }
+
     }
 
     render() {
@@ -405,10 +479,9 @@ class IRNMNGuestsSelector extends HTMLElement {
         if (!this.enableChildren || !this.enableChildrenAges) {
             return;
         }
-        const childAgeContainer = this.querySelector(
-            `.${CLASS_NAMES.childrenAgeDropdowns}`,
-        );
+        const childAgeContainer = this.getChildAgeContainerElement();
         childAgeContainer.innerHTML = ''; // Clear existing dropdowns
+
 
         for (let i = 1; i <= this.state.children; i++) {
             const ageDropdown = document.createElement('select');
@@ -417,6 +490,7 @@ class IRNMNGuestsSelector extends HTMLElement {
                 'name',
                 `${this.name}.childrenAges[${i - 1}]`,
             );
+            ageDropdown.setAttribute("required", true);
             ageDropdown.innerHTML = this.generateAgeOptions(this.maxChildAge);
 
             // Initialize childrenAges[i - 1] to 1 if not already set
@@ -424,11 +498,19 @@ class IRNMNGuestsSelector extends HTMLElement {
                 this.state.childrenAges[i - 1] = 1; // Set default age to 1
             }
 
-            ageDropdown.value = this.state.childrenAges[i - 1]; // Set the dropdown value to the initialized age
+            //ageDropdown.value = this.state.childrenAges[i - 1]; // Set the dropdown value to the initialized age
 
             // Dispatch event on change
             ageDropdown.addEventListener('change', () => {
-                this.state.childrenAges[i - 1] = parseInt(ageDropdown.value);
+                const Value = parseInt(ageDropdown.value);
+                this.state.childrenAges[i - 1] = Value;
+
+                // If the error is shown and we selected a valid value we'll remove the error message.
+                const ParentElement = ageDropdown.closest(`.${CLASS_NAMES.childAgeWrapper}`);
+                if(ParentElement?.getAttribute("show-error") === 'true' && !isNaN(Value)) {
+                    ParentElement.setAttribute("show-error", false);
+                    //this.renderErrorMessage(ParentElement, false);
+                }
 
                 // Emit custom event with the entire childrenAges array when any child age changes
                 this.dispatchEvent(
@@ -437,13 +519,20 @@ class IRNMNGuestsSelector extends HTMLElement {
                     }),
                 );
             });
+
+
+
+
             // create a label for the child age select
             const label = document.createElement('label');
             label.textContent = `${this.labels.childAge} (${i})`;
             // create a wrapper for label and select
             const ageWrapper = document.createElement('div');
-            ageWrapper.classList.add('irnmn-child-age-wrapper');
+            ageWrapper.classList.add(CLASS_NAMES.childAgeWrapper);
             ageWrapper.appendChild(label);
+            // Adding the error message so the validation script in irnmn-parent can validate these fields
+            ageWrapper.setAttribute("error-message", "Please select a child age");
+            ageWrapper.setAttribute("show-error",false);
             // create a wrapper for label and select
             const selectWrapper = document.createElement('div');
             selectWrapper.classList.add('irnmn-child-age-select-wrapper');
@@ -469,10 +558,16 @@ class IRNMNGuestsSelector extends HTMLElement {
                 detail: this.state,
             }),
         );
+
+        this.observeChildAgeSelectors();
     }
 
     generateAgeOptions(maxAge) {
         let options = '';
+        console.log("generate age options");
+
+        options += `<option value="">Select</option>`;
+
         for (let i = 1; i <= maxAge; i++) {
             options += `<option value="${i}">${i}</option>`;
         }

--- a/guests-selector/utils/constants.js
+++ b/guests-selector/utils/constants.js
@@ -7,7 +7,9 @@ export const CLASS_NAMES = {
     removeRoomBtn: `${prefix}__remove-room-btn`,
     guestControls: `${prefix}__guest-controls`,
     childrenAgeDropdowns: `${prefix}__children-age-dropdowns`,
+    childAgeWrapper: `irnmn-child-age-wrapper`,
     // from number-picker
     decrementBtn: `irnmn-number-picker__decrement-btn`,
     incrementBtn: `irnmn-number-picker__increment-btn`,
+    errorMessage: `validation-message`
 };

--- a/rooms-selector/index.js
+++ b/rooms-selector/index.js
@@ -181,10 +181,11 @@ class IRNMNRoomsSelector extends HTMLElement {
 
     /**
      * Get the child pre-selected attribute value
-     * @return {Boolean} Returns the age or -1 if invalid
+     * @return {Boolean} Returns the value of the attribute
      */
     getChildAgePreselected() {
-        return this.getAttribute('child-age-preselected') || true;
+        const childAgePreselectedAttr = this.getAttribute('child-age-preselected') || true;
+        return  childAgePreselectedAttr === 'true' || childAgePreselectedAttr === true;
     }
 
     /**

--- a/rooms-selector/index.js
+++ b/rooms-selector/index.js
@@ -45,7 +45,7 @@ class IRNMNRoomsSelector extends HTMLElement {
         this.maxChildAge = this.getMaxChildAge();
         this.labels = this.getLabels();
         this.enableMaxGuestsLabel = this.getEnableMaxGuestsLabel();
-        this.childDefaultAge = this.getChildDefaultAge();
+        this.childAgePreselected = this.getChildAgePreselected();
     }
 
     static get observedAttributes() {
@@ -180,16 +180,12 @@ class IRNMNRoomsSelector extends HTMLElement {
     }
 
     /**
-     * Get the child default age clamped value between 0-{maxChildAge} or -1 if the attribute doesn't exist or not a number
-     * @return {Number} Returns the age or -1 if invalid
+     * Get the child pre-selected attribute value
+     * @return {Boolean} Returns the age or -1 if invalid
      */
-    getChildDefaultAge() {
-        const ChildDefaultAge = parseInt(this.getAttribute('child-default-age')) || -1;
-        if(ChildDefaultAge < 1) return ChildDefaultAge;
+    getChildAgePreselected() {
+        return this.getAttribute('child-age-preselected') || true;
 
-        const ClampedChildDefaultAge = Math.min(Math.max(ChildDefaultAge, 0), this.maxChildAge);
-
-        return ClampedChildDefaultAge;
     }
 
     /**
@@ -357,7 +353,7 @@ class IRNMNRoomsSelector extends HTMLElement {
                 enable-children="${this.enableChildren}"
                 enable-children-ages="${this.enableChildrenAges}"
                 enable-max-guests-label="${this.enableMaxGuestsLabel}"
-                child-default-age="${this.childDefaultAge}"
+                child-age-preselected="${this.childAgePreselected}"
             >
             </irnmn-guests-selector>
         `;

--- a/rooms-selector/index.js
+++ b/rooms-selector/index.js
@@ -45,6 +45,7 @@ class IRNMNRoomsSelector extends HTMLElement {
         this.maxChildAge = this.getMaxChildAge();
         this.labels = this.getLabels();
         this.enableMaxGuestsLabel = this.getEnableMaxGuestsLabel();
+        this.childDefaultAge = this.getChildDefaultAge();
     }
 
     static get observedAttributes() {
@@ -176,6 +177,19 @@ class IRNMNRoomsSelector extends HTMLElement {
      */
     getMaxChildAge() {
         return parseInt(this.getAttribute('max-child-age')) || 17;
+    }
+
+    /**
+     * Get the child default age clamped value between 0-{maxChildAge} or -1 if the attribute doesn't exist or not a number
+     * @return {Number} Returns the age or -1 if invalid
+     */
+    getChildDefaultAge() {
+        const ChildDefaultAge = parseInt(this.getAttribute('child-default-age')) || -1;
+        if(ChildDefaultAge < 1) return ChildDefaultAge;
+
+        const ClampedChildDefaultAge = Math.min(Math.max(ChildDefaultAge, 0), this.maxChildAge);
+
+        return ClampedChildDefaultAge;
     }
 
     /**
@@ -329,6 +343,7 @@ class IRNMNRoomsSelector extends HTMLElement {
                 childrenAges: [], // Initialize empty array for child ages
             });
         }
+
         const roomGuestsHTML = `
             <irnmn-guests-selector
                 init-state='${JSON.stringify(roomState)}'
@@ -342,6 +357,7 @@ class IRNMNRoomsSelector extends HTMLElement {
                 enable-children="${this.enableChildren}"
                 enable-children-ages="${this.enableChildrenAges}"
                 enable-max-guests-label="${this.enableMaxGuestsLabel}"
+                child-default-age="${this.childDefaultAge}"
             >
             </irnmn-guests-selector>
         `;

--- a/rooms-selector/index.js
+++ b/rooms-selector/index.js
@@ -185,7 +185,6 @@ class IRNMNRoomsSelector extends HTMLElement {
      */
     getChildAgePreselected() {
         return this.getAttribute('child-age-preselected') || true;
-
     }
 
     /**


### PR DESCRIPTION
[IRNMN-4661 - Child Age Default](https://ennismore.atlassian.net/browse/IRNMN-4661)

**What**

Child age selector required status and error display. 

**How**

By passing the `child-age-preselected` attribute to the `rooms-selector` component, that will forward it to the `guests-selector`. This value can either be `true/false`. 
If it's `true` the component should function as before, by pre-filling the child age selector with  the value of `1`.
If it's `false`, the component will pre-fill the value with `Select` which is not a valid value and will prevent form submission. If the user has not selected an age, this will prevent form submission and will show an error below the field. 

**How to test**

Test instructions in [25Hours PR](https://github.com/ennismore/25hours-hotels-wp-theme/pull/368)

PR Checklist

- [x] Have you checked the base branch is correct for this PR?
- [x] Have you added a short description of the issue and the changes?
- [x] Have you linked a JIRA ticket to this PR?
- [x] Have you made it clear what you want the reviewer to focus on?
- [ ] Have you listed the steps needed to test locally?
- [x] Does the code being changed match with the A/C listed in the linked JIRA ticket?
- [ ] Have you uploaded additional resources like a xml file to help with local testing?
- [ ] Have you added documentation to the changes if needed?
- [ ] Have you sensed checked the changes against co-pilot or other LLM?